### PR TITLE
Nicer tooltips for time and age plots

### DIFF
--- a/src/widgets/VariantAgeDistributionPlot.tsx
+++ b/src/widgets/VariantAgeDistributionPlot.tsx
@@ -64,6 +64,9 @@ export const VariantAgeDistributionPlot = ({ data }: Props) => {
           ]}
           layout={{
             title: 'Age Distribution',
+            xaxis: {
+              title: 'Age',
+            },
             yaxis: {
               title: 'Number Sequences',
             },

--- a/src/widgets/VariantAgeDistributionPlot.tsx
+++ b/src/widgets/VariantAgeDistributionPlot.tsx
@@ -47,6 +47,7 @@ export const VariantAgeDistributionPlot = ({ data }: Props) => {
           style={{ width: '100%', height: '100%' }}
           data={[
             {
+              name: 'Sequences',
               type: 'bar',
               x: distributionData.map(d => d.x),
               y: distributionData.map(d => d.y.count),
@@ -58,6 +59,7 @@ export const VariantAgeDistributionPlot = ({ data }: Props) => {
               mode: 'lines+markers',
               marker: { color: 'red' },
               yaxis: 'y2',
+              hovertemplate: '%{y:.2f}%<extra></extra>',
             },
           ]}
           layout={{

--- a/src/widgets/VariantTimeDistributionPlot.tsx
+++ b/src/widgets/VariantTimeDistributionPlot.tsx
@@ -59,6 +59,13 @@ export const VariantTimeDistributionPlot = ({ data }: Props) => {
           ]}
           layout={{
             title: 'Time Distribution',
+            xaxis: {
+              title: 'Week',
+              type: 'date',
+              tickvals: distribution.map(d => d.x.firstDayInWeek),
+              tickformat: 'W%-V, %Y',
+              hoverformat: 'Week %-V, %Y (from %d.%m.)'
+            },
             yaxis: {
               title: 'Number Sequences',
             },

--- a/src/widgets/VariantTimeDistributionPlot.tsx
+++ b/src/widgets/VariantTimeDistributionPlot.tsx
@@ -42,6 +42,7 @@ export const VariantTimeDistributionPlot = ({ data }: Props) => {
           style={{ width: '100%', height: '100%' }}
           data={[
             {
+              name: 'Sequences',
               type: 'bar',
               x: distribution.map(d => new Date(d.x.firstDayInWeek)),
               y: distribution.map(d => d.y.count),
@@ -53,6 +54,7 @@ export const VariantTimeDistributionPlot = ({ data }: Props) => {
               mode: 'lines+markers',
               marker: { color: 'red' },
               yaxis: 'y2',
+              hovertemplate: '%{y:.2f}%<extra></extra>',
             },
           ]}
           layout={{


### PR DESCRIPTION
This fixes #3. @chaoran-chen I roughly followed your suggestion. Here are the new tooltips (age plot is the same):

![2021-02-17-120126_11520x2160_scrot](https://user-images.githubusercontent.com/1489115/108195481-1d520380-7118-11eb-9f78-c8b658ad4528.png)


I also made the X-axis in the time plot explicitly show weeks, so that it matches the tooltip. This calculates ISO 8601 weeks, instead of directly using the week numbers from the response, because that is all that the formatting system supports. Is that the correct week calculation?
