### PR TITLE
Nicer tooltips for international comparison

### DIFF
--- a/src/services/api-types.ts
+++ b/src/services/api-types.ts
@@ -105,6 +105,7 @@ export const LoginResponseSchema = z.object({
 
 // TypeScript types from schemas
 
+export type ValueWithCI = z.infer<typeof ValueWithCISchema>;
 export type Country = z.infer<typeof CountrySchema>;
 export type Sample = z.infer<typeof SampleSchema>;
 export type SampleResultList = z.infer<typeof SampleResultListSchema>;


### PR DESCRIPTION
Closes #8 as described there. I also cleaned up the trace names (they used to have `(trace 0)` at the end). The week labels are not ideal - I opened issue #12 for that. 

![2021-02-17-203912_11520x2160_scrot](https://user-images.githubusercontent.com/1489115/108258449-4eeebd00-7160-11eb-9a19-732554cba82f.png)

