### PR TITLE
Fill missing data with zeros

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -28,3 +28,4 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run check-types
+      - run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -2755,6 +2755,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -6254,6 +6260,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
     },
     "debug": {
       "version": "4.3.1",
@@ -12111,9 +12122,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
       "version": "4.17.20",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@types/topojson-client": "^3.0.0",
     "bootstrap": "^4.5.3",
     "d3": "^6.5.0",
+    "dayjs": "^1.10.4",
+    "lodash": "^4.17.21",
     "plotly.js": "^1.58.4",
     "react": "^17.0.1",
     "react-bootstrap": "^1.4.3",
@@ -68,6 +70,7 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.168",
     "@types/react-bootstrap-typeahead": "^5.1.2",
     "@types/react-plotly.js": "^2.2.4",
     "prettier": "^2.2.1"

--- a/src/components/NewVariantLookup.tsx
+++ b/src/components/NewVariantLookup.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Col } from 'react-bootstrap';
 import Form from 'react-bootstrap/Form';
+import { parseYearWeekString } from '../helpers/week';
 import { getCurrentWeek } from '../services/api';
-import { Country, parseYearWeekString, Variant } from '../services/api-types';
+import { Country, Variant } from '../services/api-types';
 import { NewVariantTable } from './NewVariantTable';
 
 interface Props {

--- a/src/helpers/__tests__/fill-missing.test.ts
+++ b/src/helpers/__tests__/fill-missing.test.ts
@@ -1,35 +1,111 @@
-import { TimeDistributionEntry } from '../../services/api-types';
-import { addDayToYearWeek } from '../week';
+import { shuffle } from 'lodash';
 import { fillWeeklyApiData } from '../fill-missing';
+import { addDayToYearWeek } from '../week';
 
-describe('fillApiWeeklyData', () => {
-  test('single input element', () => {
-    const emptyY: TimeDistributionEntry['y'] = {
-      count: 0,
-      total: 0,
-      proportion: {
-        value: 0,
-        ciLower: 0,
-        ciUpper: 0,
-        confidenceLevel: 0,
-      },
-    };
-    const inputData: TimeDistributionEntry[] = [
-      {
-        x: addDayToYearWeek('2023-07'),
-        y: {
-          count: 20,
-          total: 517,
-          proportion: {
-            value: 0.04,
-            ciLower: 0.035,
-            ciUpper: 0.048,
-            confidenceLevel: 0.95,
-          },
-        },
-      },
-    ];
-    const actualOutputData: TimeDistributionEntry[] = fillWeeklyApiData(inputData, emptyY);
-    expect(actualOutputData).toEqual(inputData);
-  });
+describe('fillWeeklyApiData', () => {
+  interface Case {
+    label: string;
+    input: [string, number][];
+    fillValue: number;
+    output: [string, number][];
+  }
+  const cases: Case[] = [
+    {
+      label: 'empty input',
+      input: [],
+      fillValue: 123,
+      output: [],
+    },
+    {
+      label: '1 week',
+      input: [['2012-07', 20]],
+      fillValue: 123,
+      output: [['2012-07', 20]],
+    },
+    {
+      label: '2 consecutive weeks',
+      input: [
+        ['2012-07', 20],
+        ['2012-08', 13],
+      ],
+      fillValue: 123,
+      output: [
+        ['2012-07', 20],
+        ['2012-08', 13],
+      ],
+    },
+    {
+      label: '2 weeks with space in between',
+      input: [
+        ['2012-07', 20],
+        ['2012-11', 13],
+      ],
+      fillValue: 123,
+      output: [
+        ['2012-07', 20],
+        ['2012-08', 123],
+        ['2012-09', 123],
+        ['2012-10', 123],
+        ['2012-11', 13],
+      ],
+    },
+    {
+      label: 'multiple weeks with no space in between',
+      input: [
+        ['2012-07', 20],
+        ['2012-08', 13],
+        ['2012-09', 13],
+        ['2012-10', 13],
+      ],
+      fillValue: 123,
+      output: [
+        ['2012-07', 20],
+        ['2012-08', 13],
+        ['2012-09', 13],
+        ['2012-10', 13],
+      ],
+    },
+    {
+      label: 'crossing a year border (52 weeks)',
+      input: [
+        ['2012-50', 8],
+        ['2013-02', 3],
+      ],
+      fillValue: 0,
+      output: [
+        ['2012-50', 8],
+        ['2012-51', 0],
+        ['2012-52', 0],
+        ['2013-01', 0],
+        ['2013-02', 3],
+      ],
+    },
+    {
+      label: 'crossing a year border (53 weeks)',
+      input: [
+        ['2015-52', 8],
+        ['2016-01', 3],
+      ],
+      fillValue: 0,
+      output: [
+        ['2015-52', 8],
+        ['2015-53', 0],
+        ['2016-01', 3],
+      ],
+    },
+  ];
+
+  const fromTemplate = (template: [string, number][]) =>
+    template.map(([yearWeek, y]) => ({ x: addDayToYearWeek(yearWeek), y }));
+
+  for (const c of cases) {
+    // eslint-disable-next-line jest/valid-title
+    test(c.label, () => {
+      const expectedOutput = fromTemplate(c.output);
+      for (let i = 0; i < 10; i++) {
+        const shuffledInput = shuffle(fromTemplate(c.input));
+        expect(fillWeeklyApiData<number>(shuffledInput, c.fillValue)).toEqual(expectedOutput);
+      }
+    });
+  }
 });

--- a/src/helpers/__tests__/fill-missing.test.ts
+++ b/src/helpers/__tests__/fill-missing.test.ts
@@ -1,0 +1,35 @@
+import { TimeDistributionEntry } from '../../services/api-types';
+import { addDayToYearWeek } from '../week';
+import { fillWeeklyApiData } from '../fill-missing';
+
+describe('fillApiWeeklyData', () => {
+  test('single input element', () => {
+    const emptyY: TimeDistributionEntry['y'] = {
+      count: 0,
+      total: 0,
+      proportion: {
+        value: 0,
+        ciLower: 0,
+        ciUpper: 0,
+        confidenceLevel: 0,
+      },
+    };
+    const inputData: TimeDistributionEntry[] = [
+      {
+        x: addDayToYearWeek('2023-07'),
+        y: {
+          count: 20,
+          total: 517,
+          proportion: {
+            value: 0.04,
+            ciLower: 0.035,
+            ciUpper: 0.048,
+            confidenceLevel: 0.95,
+          },
+        },
+      },
+    ];
+    const actualOutputData: TimeDistributionEntry[] = fillWeeklyApiData(inputData, emptyY);
+    expect(actualOutputData).toEqual(inputData);
+  });
+});

--- a/src/helpers/__tests__/fill-missing.test.ts
+++ b/src/helpers/__tests__/fill-missing.test.ts
@@ -1,5 +1,5 @@
 import { shuffle, sortBy } from 'lodash';
-import { fillGroupedWeeklyApiData, fillWeeklyApiData } from '../fill-missing';
+import { fillAgeKeyedApiData, fillGroupedWeeklyApiData, fillWeeklyApiData } from '../fill-missing';
 import { addDayToYearWeek } from '../week';
 
 describe('fillWeeklyApiData', () => {
@@ -127,5 +127,64 @@ describe('fillGroupedWeeklyApiData', () => {
       { x: { country: 'Germany', week: addDayToYearWeek('2020-27') }, y: 60 },
       { x: { country: 'Switzerland', week: addDayToYearWeek('2020-18') }, y: 123 },
     ]);
+  }
+});
+
+describe('fillAgeKeyedApiData', () => {
+  interface Case {
+    label: string;
+    input: [string, number][];
+    fillValue: number;
+    output: [string, number][];
+  }
+  const cases: Case[] = [
+    {
+      label: 'empty input',
+      input: [],
+      fillValue: 123,
+      output: [
+        ['0-9', 123],
+        ['10-19', 123],
+        ['20-29', 123],
+        ['30-39', 123],
+        ['40-49', 123],
+        ['50-59', 123],
+        ['60-69', 123],
+        ['70-79', 123],
+        ['80+', 123],
+      ],
+    },
+    {
+      label: 'input with some ages',
+      input: [
+        ['20-29', 18],
+        ['50-59', 30],
+      ],
+      fillValue: 123,
+      output: [
+        ['0-9', 123],
+        ['10-19', 123],
+        ['20-29', 18],
+        ['30-39', 123],
+        ['40-49', 123],
+        ['50-59', 30],
+        ['60-69', 123],
+        ['70-79', 123],
+        ['80+', 123],
+      ],
+    },
+  ];
+
+  const fromTemplate = (template: [string, number][]) => template.map(([x, y]) => ({ x, y }));
+
+  for (const c of cases) {
+    // eslint-disable-next-line jest/valid-title
+    test(c.label, () => {
+      const expectedOutput = fromTemplate(c.output);
+      for (let i = 0; i < 5; i++) {
+        const shuffledInput = shuffle(fromTemplate(c.input));
+        expect(fillAgeKeyedApiData(shuffledInput, c.fillValue)).toEqual(expectedOutput);
+      }
+    });
   }
 });

--- a/src/helpers/__tests__/fill-missing.test.ts
+++ b/src/helpers/__tests__/fill-missing.test.ts
@@ -1,5 +1,5 @@
-import { shuffle } from 'lodash';
-import { fillWeeklyApiData } from '../fill-missing';
+import { shuffle, sortBy } from 'lodash';
+import { fillGroupedWeeklyApiData, fillWeeklyApiData } from '../fill-missing';
 import { addDayToYearWeek } from '../week';
 
 describe('fillWeeklyApiData', () => {
@@ -102,10 +102,30 @@ describe('fillWeeklyApiData', () => {
     // eslint-disable-next-line jest/valid-title
     test(c.label, () => {
       const expectedOutput = fromTemplate(c.output);
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 5; i++) {
         const shuffledInput = shuffle(fromTemplate(c.input));
         expect(fillWeeklyApiData<number>(shuffledInput, c.fillValue)).toEqual(expectedOutput);
       }
     });
+  }
+});
+
+describe('fillGroupedWeeklyApiData', () => {
+  for (let i = 0; i < 5; i++) {
+    const shuffledInput = shuffle([
+      { x: { country: 'Germany', week: addDayToYearWeek('2020-25') }, y: 50 },
+      { x: { country: 'Switzerland', week: addDayToYearWeek('2020-18') }, y: 123 },
+      { x: { country: 'Germany', week: addDayToYearWeek('2020-27') }, y: 60 },
+    ]);
+    const actualSortedOutput = sortBy(fillGroupedWeeklyApiData(shuffledInput, 'country', 0), [
+      v => v.x.country,
+      v => v.x.week.firstDayInWeek,
+    ]);
+    expect(actualSortedOutput).toEqual([
+      { x: { country: 'Germany', week: addDayToYearWeek('2020-25') }, y: 50 },
+      { x: { country: 'Germany', week: addDayToYearWeek('2020-26') }, y: 0 },
+      { x: { country: 'Germany', week: addDayToYearWeek('2020-27') }, y: 60 },
+      { x: { country: 'Switzerland', week: addDayToYearWeek('2020-18') }, y: 123 },
+    ]);
   }
 });

--- a/src/helpers/__tests__/fill-missing.test.ts
+++ b/src/helpers/__tests__/fill-missing.test.ts
@@ -187,4 +187,16 @@ describe('fillAgeKeyedApiData', () => {
       }
     });
   }
+
+  test('throws on bad age values', () => {
+    expect(() =>
+      fillAgeKeyedApiData(
+        fromTemplate([
+          ['10-19', 100],
+          ['25-28', 50],
+        ]),
+        0
+      )
+    ).toThrow();
+  });
 });

--- a/src/helpers/__tests__/week.test.ts
+++ b/src/helpers/__tests__/week.test.ts
@@ -42,38 +42,42 @@ describe('parseYearWeekString', () => {
 });
 
 describe('conversions between year-week strings and dayjs', () => {
-  interface EquivalenceClass {
+  interface Case {
+    label: string;
     firstDayInWeek: string;
     yearWeekStrings: string[];
   }
-  const equivalenceClasses: EquivalenceClass[] = [
+  const cases: Case[] = [
     {
+      label: 'typical case',
       firstDayInWeek: '2021-03-29',
       yearWeekStrings: ['2021-13'],
     },
     {
+      label: 'getting the 1st week of a year',
       firstDayInWeek: '2021-01-04',
       yearWeekStrings: ['2021-01', '2021-1'],
     },
     {
-      // Year of ISO week and year of start day don't match
+      label: "year of ISO week and year of start day don't match",
       firstDayInWeek: '2018-12-31',
       yearWeekStrings: ['2019-01', '2019-1'],
     },
     {
-      // Getting 53rd week of a year with 53 weeks
+      label: 'getting the 53rd week of a year with 53 weeks',
       firstDayInWeek: '2020-12-28',
       yearWeekStrings: ['2020-53'],
     },
     {
-      // Getting 52nd week of a year with 52 weeks
+      label: 'getting the 52nd week of a year with 52 weeks',
       firstDayInWeek: '2019-12-23',
       yearWeekStrings: ['2019-52'],
     },
   ];
 
-  for (const c of equivalenceClasses) {
-    test(`convert between formats of week starting on ${c.firstDayInWeek}`, () => {
+  for (const c of cases) {
+    // eslint-disable-next-line jest/valid-title
+    test(c.label, () => {
       for (const yearWeekString of c.yearWeekStrings) {
         const resultDayjs = yearWeekWithDayToDayjs({
           yearWeek: yearWeekString,

--- a/src/helpers/__tests__/week.test.ts
+++ b/src/helpers/__tests__/week.test.ts
@@ -1,0 +1,96 @@
+import {
+  dayjsToYearWeekString,
+  dayjsToYearWeekWithDay,
+  parseYearWeekString,
+  yearWeekStringToDayjs,
+  yearWeekWithDayToDayjs,
+} from '../week';
+
+describe('parseYearWeekString', () => {
+  const goodCases: [string, number, number][] = [
+    ['2020-07', 2020, 7],
+    ['2020-7', 2020, 7],
+    ['2020-15', 2020, 15],
+    ['2020-01', 2020, 1],
+    ['2020-52', 2020, 52],
+    ['2020-53', 2020, 53],
+  ];
+  const badCases: string[] = [
+    '2020-0',
+    '2020-00',
+    '2020-000',
+    '2020-007',
+    '07-2020',
+    '15-2020',
+    '20-07',
+    '',
+    '2020',
+    '2020-54',
+  ];
+
+  for (const c of goodCases) {
+    test(`parse "${c[0]}"`, () => {
+      expect(parseYearWeekString(c[0])).toEqual({ year: c[1], week: c[2] });
+    });
+  }
+
+  for (const c of badCases) {
+    test(`parse "${c}" should fail`, () => {
+      expect(() => parseYearWeekString(c)).toThrow();
+    });
+  }
+});
+
+describe('conversions between year-week strings and dayjs', () => {
+  interface EquivalenceClass {
+    firstDayInWeek: string;
+    yearWeekStrings: string[];
+  }
+  const equivalenceClasses: EquivalenceClass[] = [
+    {
+      firstDayInWeek: '2021-03-29',
+      yearWeekStrings: ['2021-13'],
+    },
+    {
+      firstDayInWeek: '2021-01-04',
+      yearWeekStrings: ['2021-01', '2021-1'],
+    },
+    {
+      // Year of ISO week and year of start day don't match
+      firstDayInWeek: '2018-12-31',
+      yearWeekStrings: ['2019-01', '2019-1'],
+    },
+    {
+      // Getting 53rd week of a year with 53 weeks
+      firstDayInWeek: '2020-12-28',
+      yearWeekStrings: ['2020-53'],
+    },
+    {
+      // Getting 52nd week of a year with 52 weeks
+      firstDayInWeek: '2019-12-23',
+      yearWeekStrings: ['2019-52'],
+    },
+  ];
+
+  for (const c of equivalenceClasses) {
+    test(`convert between formats of week starting on ${c.firstDayInWeek}`, () => {
+      for (const yearWeekString of c.yearWeekStrings) {
+        const resultDayjs = yearWeekWithDayToDayjs({
+          yearWeek: yearWeekString,
+          firstDayInWeek: c.firstDayInWeek,
+        });
+        expect(yearWeekStringToDayjs(yearWeekString).isSame(resultDayjs)).toBe(true);
+        expect(resultDayjs.format('YYYY-MM-DD')).toEqual(c.firstDayInWeek);
+        expect(c.yearWeekStrings).toContain(dayjsToYearWeekString(resultDayjs));
+        expect(dayjsToYearWeekWithDay(resultDayjs).firstDayInWeek).toEqual(c.firstDayInWeek);
+      }
+    });
+  }
+
+  test('throws on bad input', () => {
+    expect(() => yearWeekStringToDayjs('20-15')).toThrow();
+    expect(() => yearWeekStringToDayjs('2017-53')).toThrow(); // 2017 has 52 ISO weeks
+    expect(() => yearWeekStringToDayjs('2017-54')).toThrow(); // 2020 has 53 ISO weeks
+    expect(() => yearWeekWithDayToDayjs({ yearWeek: '2021-13', firstDayInWeek: '2021-03-30' })).toThrow(); // firstDayInWeek is wrong
+  });
+});

--- a/src/helpers/confidence-interval.ts
+++ b/src/helpers/confidence-interval.ts
@@ -1,4 +1,3 @@
-import { any } from 'zod';
 import { CountAndProportionWithCI } from '../services/api-types';
 
 export type EntryWithoutCI<T extends { y: CountAndProportionWithCI }> = Omit<T, 'y'> & {

--- a/src/helpers/confidence-interval.ts
+++ b/src/helpers/confidence-interval.ts
@@ -1,0 +1,13 @@
+import { any } from 'zod';
+import { CountAndProportionWithCI } from '../services/api-types';
+
+export type EntryWithoutCI<T extends { y: CountAndProportionWithCI }> = Omit<T, 'y'> & {
+  y: { count: number; proportion: number };
+};
+
+export function removeCIFromEntry<T extends { y: CountAndProportionWithCI }>(entry: T): EntryWithoutCI<T> {
+  return {
+    ...entry,
+    y: { count: entry.y.count, proportion: entry.y.proportion.value },
+  };
+}

--- a/src/helpers/fill-missing.ts
+++ b/src/helpers/fill-missing.ts
@@ -63,7 +63,7 @@ class NoopFiller<T> implements RangeFiller<T> {
 class IsoWeekFiller implements RangeFiller<Dayjs> {
   private current: Dayjs;
 
-  constructor(private min: Dayjs, private max: Dayjs) {
+  constructor(min: Dayjs, private max: Dayjs) {
     assert(min.startOf('isoWeek').isSame(min));
     assert(max.startOf('isoWeek').isSame(max));
     if (!(min.isBefore(max) || min.isSame(max))) {

--- a/src/helpers/fill-missing.ts
+++ b/src/helpers/fill-missing.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import dayjs, { Dayjs } from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
-import { last, sortBy, groupBy } from 'lodash';
-import { YearWeekWithDay, YearWeekWithDaySchema } from '../services/api-types';
+import { groupBy, last, sortBy } from 'lodash';
+import { YearWeekWithDay } from '../services/api-types';
 import { dayjsToYearWeekWithDay, yearWeekWithDayToDayjs } from './week';
 
 dayjs.extend(isoWeek);

--- a/src/helpers/fill-missing.ts
+++ b/src/helpers/fill-missing.ts
@@ -1,0 +1,76 @@
+import dayjs, { Dayjs } from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import { last, sortBy } from 'lodash';
+import { YearWeekWithDay } from '../services/api-types';
+import { dayjsToYearWeekWithDay, yearWeekWithDayToDayjs } from './week';
+
+dayjs.extend(isoWeek);
+
+interface RangeFiller<T> {
+  next(nextOriginal: T | undefined): { useOriginal: true } | { useOriginal: false; fill: T } | undefined;
+}
+
+function fillMissingData<X, Y, FK>(
+  unsortedOriginalData: { x: X; y: Y }[],
+  Filler: { new (min: FK, max: FK): RangeFiller<FK> },
+  getFillerKey: (x: X) => FK,
+  getSortKey: (fillerKey: FK) => unknown,
+  makeFillerElement: (fillerKey: FK) => { x: X; y: Y }
+): { x: X; y: Y }[] {
+  if (!unsortedOriginalData.length) {
+    return [];
+  }
+
+  const sortedOriginalData = sortBy(unsortedOriginalData, ({ x }) => getSortKey(getFillerKey(x)));
+  const filler = new Filler(getFillerKey(sortedOriginalData[0].x), getFillerKey(last(sortedOriginalData)!.x));
+
+  const output = [];
+  for (const original of sortedOriginalData) {
+    while (true) {
+      const next = filler.next(getFillerKey(original.x));
+      if (!next) {
+        throw new Error('filler stopped providing data while in original range');
+      }
+      if (next.useOriginal) {
+        output.push(original);
+        break;
+      } else {
+        output.push(makeFillerElement(next.fill));
+      }
+    }
+  }
+  while (true) {
+    const next = filler.next(undefined);
+    if (!next) {
+      break;
+    }
+    if (next.useOriginal) {
+      throw new Error('filler.next() returned useOriginal although no original value was passed');
+    }
+    output.push(makeFillerElement(next.fill));
+  }
+  return output;
+}
+
+class IsoWeekFiller implements RangeFiller<Dayjs> {
+  constructor(private min: Dayjs, private max: Dayjs) {}
+
+  next(
+    nextOriginal: Dayjs | undefined
+  ): { useOriginal: true } | { useOriginal: false; fill: Dayjs } | undefined {
+    throw new Error('not implemented');
+  }
+}
+
+export function fillApiWeeklyData<Y>(
+  unsortedOriginalData: { x: YearWeekWithDay; y: Y }[],
+  fillerY: Y
+): { x: YearWeekWithDay; y: Y }[] {
+  return fillMissingData(
+    unsortedOriginalData,
+    IsoWeekFiller,
+    yearWeekWithDayToDayjs,
+    v => [v.isoWeekYear(), v.isoWeek()],
+    v => ({ x: dayjsToYearWeekWithDay(v), y: fillerY })
+  );
+}

--- a/src/helpers/week.ts
+++ b/src/helpers/week.ts
@@ -43,3 +43,7 @@ export function dayjsToYearWeekWithDay(yearWeek: Dayjs): YearWeekWithDay {
     firstDayInWeek: yearWeek.startOf('isoWeek').format('YYYY-MM-DD'),
   };
 }
+
+export function addDayToYearWeek(yearWeek: string): YearWeekWithDay {
+  return dayjsToYearWeekWithDay(yearWeekStringToDayjs(yearWeek));
+}

--- a/src/helpers/week.ts
+++ b/src/helpers/week.ts
@@ -1,0 +1,43 @@
+import assert from 'assert';
+import dayjs, { Dayjs } from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import { yearWeekRegex, YearWeekWithDay } from '../services/api-types';
+
+dayjs.extend(isoWeek);
+
+export function parseYearWeekString(yearWeek: string): { year: number; week: number } {
+  const m = yearWeek.match(yearWeekRegex);
+  if (!m) {
+    throw new Error('invalid YearWeek string');
+  }
+  const parsed = { year: +m[1], week: +m[2] };
+  if (!(parsed.week >= 1 && parsed.week <= 53)) {
+    throw new Error('invalid week in YearWeek string');
+  }
+  return parsed;
+}
+
+export function yearWeekStringToDayjs(yearWeek: string): Dayjs {
+  const { year, week } = parseYearWeekString(yearWeek);
+  // "The first week of the year, hence, always contains 4 January." https://en.wikipedia.org/wiki/ISO_week_date
+  const output = dayjs().year(year).month(1).date(4).isoWeek(week).startOf('isoWeek');
+  assert(output.isoWeek() === week && output.isoWeekYear() === year, 'conversion to dayjs was wrong');
+  return output;
+}
+
+export function yearWeekWithDayToDayjs(input: YearWeekWithDay): Dayjs {
+  const output = yearWeekStringToDayjs(input.yearWeek);
+  assert(dayjsToYearWeekWithDay(output).firstDayInWeek === input.firstDayInWeek);
+  return output;
+}
+
+export function dayjsToYearWeekString(yearWeek: Dayjs): string {
+  return `${yearWeek.isoWeekYear()}-${yearWeek.isoWeek()}`;
+}
+
+export function dayjsToYearWeekWithDay(yearWeek: Dayjs): YearWeekWithDay {
+  return {
+    yearWeek: `${yearWeek.isoWeekYear()}-${yearWeek.isoWeek()}`,
+    firstDayInWeek: yearWeek.startOf('isoWeek').format('YYYY-MM-DD'),
+  };
+}

--- a/src/helpers/week.ts
+++ b/src/helpers/week.ts
@@ -5,6 +5,8 @@ import { yearWeekRegex, YearWeekWithDay } from '../services/api-types';
 
 dayjs.extend(isoWeek);
 
+// parseYearWeekString extracts the ISO week and year from a string.
+// It will **not check** whether there is actually a week 53 in the specified year.
 export function parseYearWeekString(yearWeek: string): { year: number; week: number } {
   const m = yearWeek.match(yearWeekRegex);
   if (!m) {
@@ -27,7 +29,7 @@ export function yearWeekStringToDayjs(yearWeek: string): Dayjs {
 
 export function yearWeekWithDayToDayjs(input: YearWeekWithDay): Dayjs {
   const output = yearWeekStringToDayjs(input.yearWeek);
-  assert(dayjsToYearWeekWithDay(output).firstDayInWeek === input.firstDayInWeek);
+  assert.strictEqual(dayjsToYearWeekWithDay(output).firstDayInWeek, input.firstDayInWeek);
   return output;
 }
 

--- a/src/services/api-types.ts
+++ b/src/services/api-types.ts
@@ -115,6 +115,7 @@ export interface Selection {
 // TypeScript types from schemas
 
 export type ValueWithCI = zod.infer<typeof ValueWithCISchema>;
+export type CountAndProportionWithCI = zod.infer<typeof CountAndProportionWithCISchema>;
 export type YearWeekWithDay = zod.infer<typeof YearWeekWithDaySchema>;
 export type Country = zod.infer<typeof CountrySchema>;
 export type Sample = zod.infer<typeof SampleSchema>;

--- a/src/services/api-types.ts
+++ b/src/services/api-types.ts
@@ -15,21 +15,8 @@ export const CountAndProportionWithCISchema = zod.object({
   proportion: ValueWithCISchema,
 });
 
-const yearWeekRegex = /^(\d{4})-(\d{1,2})$/;
+export const yearWeekRegex = /^(\d{4})-(\d{1,2})$/;
 export const YearWeekSchema = zod.string().regex(yearWeekRegex);
-export function parseYearWeekString(
-  yearWeek: zod.infer<typeof YearWeekSchema>
-): { year: number; week: number } {
-  const m = yearWeek.match(yearWeekRegex);
-  if (!m) {
-    throw new Error('invalid YearWeek string');
-  }
-  const parsed = { year: +m[1], week: +m[2] };
-  if (!(parsed.week >= 1 && parsed.week <= 53)) {
-    throw new Error('invalid week in YearWeek string');
-  }
-  return parsed;
-}
 
 export const YearWeekWithDaySchema = zod.object({
   yearWeek: YearWeekSchema,
@@ -128,6 +115,7 @@ export interface Selection {
 // TypeScript types from schemas
 
 export type ValueWithCI = zod.infer<typeof ValueWithCISchema>;
+export type YearWeekWithDay = zod.infer<typeof YearWeekWithDaySchema>;
 export type Country = zod.infer<typeof CountrySchema>;
 export type Sample = zod.infer<typeof SampleSchema>;
 export type SampleResultList = zod.infer<typeof SampleResultListSchema>;

--- a/src/widgets/VariantAgeDistributionPlot.tsx
+++ b/src/widgets/VariantAgeDistributionPlot.tsx
@@ -7,20 +7,13 @@ import { Widget } from './Widget';
 import * as zod from 'zod';
 import { ZodQueryEncoder } from '../helpers/query-encoder';
 import { fillAgeKeyedApiData } from '../helpers/fill-missing';
+import { EntryWithoutCI, removeCIFromEntry } from '../helpers/confidence-interval';
 
 const PropsSchema = SampleSelectorSchema;
 type Props = zod.infer<typeof PropsSchema>;
 
-interface EntryWithoutCI {
-  x: AgeDistributionEntry['x'];
-  y: {
-    count: number;
-    proportion: number;
-  };
-}
-
 const VariantAgeDistributionPlot = ({ country, mutations, matchPercentage }: Props) => {
-  const [distributionData, setDistributionData] = useState<EntryWithoutCI[] | undefined>(undefined);
+  const [distributionData, setDistributionData] = useState<EntryWithoutCI<AgeDistributionEntry>[]>();
 
   useEffect(() => {
     let isSubscribed = true;
@@ -30,13 +23,7 @@ const VariantAgeDistributionPlot = ({ country, mutations, matchPercentage }: Pro
       .then(newDistributionData => {
         if (isSubscribed) {
           setDistributionData(
-            fillAgeKeyedApiData(
-              newDistributionData.map(({ x, y }) => ({
-                x,
-                y: { count: y.count, proportion: y.proportion.value },
-              })),
-              { count: 0, proportion: 0 }
-            )
+            fillAgeKeyedApiData(newDistributionData.map(removeCIFromEntry), { count: 0, proportion: 0 })
           );
         }
       })

--- a/src/widgets/VariantInternationalComparisonPlot.tsx
+++ b/src/widgets/VariantInternationalComparisonPlot.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import * as zod from 'zod';
 import { Plot } from '../components/Plot';
+import { EntryWithoutCI, removeCIFromEntry } from '../helpers/confidence-interval';
 import { fillGroupedWeeklyApiData } from '../helpers/fill-missing';
 import { ZodQueryEncoder } from '../helpers/query-encoder';
 import { SampleSelectorSchema } from '../helpers/sample-selector';
@@ -17,16 +18,10 @@ const PropsSchema = SampleSelectorSchema.merge(
 );
 type Props = zod.infer<typeof PropsSchema>;
 
-interface EntryWithoutCI {
-  x: InternationalTimeDistributionEntry['x'];
-  y: {
-    count: number;
-    proportion: number;
-  };
-}
-
 const VariantInternationalComparisonPlot = ({ country, mutations, matchPercentage, logScale }: Props) => {
-  const [plotData, setPlotData] = useState<EntryWithoutCI[] | undefined>(undefined);
+  const [plotData, setPlotData] = useState<EntryWithoutCI<InternationalTimeDistributionEntry>[] | undefined>(
+    undefined
+  );
   const [colorMap, setColorMap] = useState<any>(null);
 
   useEffect(() => {
@@ -57,11 +52,7 @@ const VariantInternationalComparisonPlot = ({ country, mutations, matchPercentag
         }
         setColorMap(newColorMap);
         setPlotData(
-          fillGroupedWeeklyApiData(
-            newPlotData.map(({ x, y }) => ({ x, y: { count: y.count, proportion: y.proportion.value } })),
-            'country',
-            { count: 0, proportion: 0 }
-          )
+          fillGroupedWeeklyApiData(newPlotData.map(removeCIFromEntry), 'country', { count: 0, proportion: 0 })
         );
       }
     });

--- a/src/widgets/VariantInternationalComparisonPlot.tsx
+++ b/src/widgets/VariantInternationalComparisonPlot.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import * as zod from 'zod';
 import { Plot } from '../components/Plot';
 import { EntryWithoutCI, removeCIFromEntry } from '../helpers/confidence-interval';
@@ -62,23 +62,28 @@ const VariantInternationalComparisonPlot = ({ country, mutations, matchPercentag
     };
   }, [country, mutations, matchPercentage]);
 
+  const filteredPlotData = useMemo(() => plotData?.filter(v => !logScale || v.y.proportion > 0), [
+    plotData,
+    logScale,
+  ]);
+
   return (
     <div style={{ height: '100%' }}>
-      {!plotData && <p>Loading...</p>}
-      {plotData && (
+      {!filteredPlotData && <p>Loading...</p>}
+      {filteredPlotData && (
         <Plot
           style={{ width: '100%', height: '100%' }}
           data={[
             {
               type: 'scatter',
               mode: 'lines+markers',
-              x: plotData.map(d => d.x.week.firstDayInWeek),
-              y: plotData.map(d => digitsForPercent(d.y.proportion)),
-              text: plotData.map(d => `${digitsForPercent(d.y.proportion)}%`),
+              x: filteredPlotData.map(d => d.x.week.firstDayInWeek),
+              y: filteredPlotData.map(d => digitsForPercent(d.y.proportion)),
+              text: filteredPlotData.map(d => `${digitsForPercent(d.y.proportion)}%`),
               transforms: [
                 {
                   type: 'groupby',
-                  groups: plotData.map(d => d.x.country),
+                  groups: filteredPlotData.map(d => d.x.country),
                   styles: colorMap,
                   nameformat: '%{group}',
                 },
@@ -91,7 +96,7 @@ const VariantInternationalComparisonPlot = ({ country, mutations, matchPercentag
             xaxis: {
               title: 'Week',
               type: 'date',
-              tickvals: plotData.map(d => d.x.week.firstDayInWeek),
+              tickvals: filteredPlotData.map(d => d.x.week.firstDayInWeek),
               tickformat: 'W%-V, %Y',
               hoverformat: 'Week %-V, %Y (from %d.%m.)',
             },

--- a/src/widgets/VariantTimeDistributionPlot.tsx
+++ b/src/widgets/VariantTimeDistributionPlot.tsx
@@ -7,20 +7,15 @@ import { Widget } from './Widget';
 import * as zod from 'zod';
 import { ZodQueryEncoder } from '../helpers/query-encoder';
 import { fillWeeklyApiData } from '../helpers/fill-missing';
+import { EntryWithoutCI, removeCIFromEntry } from '../helpers/confidence-interval';
 
 const PropsSchema = SampleSelectorSchema;
 type Props = zod.infer<typeof PropsSchema>;
 
-interface EntryWithoutCI {
-  x: TimeDistributionEntry['x'];
-  y: {
-    count: number;
-    proportion: number;
-  };
-}
-
 export const VariantTimeDistributionPlot = ({ country, mutations, matchPercentage }: Props) => {
-  const [distribution, setDistribution] = useState<EntryWithoutCI[] | undefined>(undefined);
+  const [distribution, setDistribution] = useState<EntryWithoutCI<TimeDistributionEntry>[] | undefined>(
+    undefined
+  );
 
   useEffect(() => {
     let isSubscribed = true;
@@ -30,13 +25,7 @@ export const VariantTimeDistributionPlot = ({ country, mutations, matchPercentag
       newDistributionData => {
         if (isSubscribed) {
           setDistribution(
-            fillWeeklyApiData(
-              newDistributionData.map(({ x, y }) => ({
-                x,
-                y: { count: y.count, proportion: y.proportion.value },
-              })),
-              { count: 0, proportion: 0 }
-            )
+            fillWeeklyApiData(newDistributionData.map(removeCIFromEntry), { count: 0, proportion: 0 })
           );
         }
       }


### PR DESCRIPTION
This closes #15. It fills data in all of our plots (time, demographics and international). The plots where x is time are filled between the first and last week that is present in each series (so countries in international are filled independently). The age plot is filled according to our fixed buckets ("0-9", "10-19", etc). The log plot (international) now fillters out zero values (since they exist now) as originally requested in #10.

I added lodash, dayjs (a date library) and some helper functions for working with year-week strings - you might find those useful in the future. 

Note I removed confidence intervals from the state, since we are not showing them anywhere, and zero-filled values don't really have a defined confidence interval. We can add them back and make them optional later if we ever need them.