### PR TITLE
Random-samples-only filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,9 +12,9 @@ import { ExploreFocusSplit } from './pages/ExploreFocusSplit';
 import { LoginPage } from './pages/LoginPage';
 import { GlobalSamplePage } from './pages/GlobalSamplePage';
 import { useSamplingStrategy } from './components/HeaderSamplingStrategySelect';
+import { SamplingStrategy } from './services/api';
 
 export const App = () => {
-  // TODO
   const samplingStrategyProps = useSamplingStrategy();
 
   return (
@@ -25,7 +25,7 @@ export const App = () => {
 
       <Switch>
         <Route exact path='/'>
-          <Redirect to='/explore/Switzerland' />
+          <Redirect to={`/explore/Switzerland/${SamplingStrategy.AllSamples}`} />
         </Route>
         <Route path='/variant'>
           {/* This is so that we don't break old bookmarked links */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,15 @@ import { AboutPage } from './pages/AboutPage';
 import { ExploreFocusSplit } from './pages/ExploreFocusSplit';
 import { LoginPage } from './pages/LoginPage';
 import { GlobalSamplePage } from './pages/GlobalSamplePage';
+import { useSamplingStrategy } from './components/HeaderSamplingStrategySelect';
 
 export const App = () => {
+  const samplingStrategyProps = useSamplingStrategy();
+
   return (
     <OuterWrapper>
       <HeaderWrapper>
-        <Header />
+        <Header samplingStrategyProps={samplingStrategyProps} />
       </HeaderWrapper>
 
       <Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,25 +2,22 @@ import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { Header } from './Header';
 import {
-  ScrollableFullContentWrapper,
   HeaderWrapper,
   LoginWrapper,
   OuterWrapper,
+  ScrollableFullContentWrapper,
 } from './helpers/app-layout';
 import { AboutPage } from './pages/AboutPage';
 import { ExploreFocusSplit } from './pages/ExploreFocusSplit';
-import { LoginPage } from './pages/LoginPage';
 import { GlobalSamplePage } from './pages/GlobalSamplePage';
-import { useSamplingStrategy } from './components/HeaderSamplingStrategySelect';
+import { LoginPage } from './pages/LoginPage';
 import { SamplingStrategy } from './services/api';
 
 export const App = () => {
-  const samplingStrategyProps = useSamplingStrategy();
-
   return (
     <OuterWrapper>
       <HeaderWrapper>
-        <Header samplingStrategyProps={samplingStrategyProps} />
+        <Header />
       </HeaderWrapper>
 
       <Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { useSamplingStrategy } from './components/HeaderSamplingStrategySelect';
 
 export const App = () => {
   const samplingStrategyProps = useSamplingStrategy();
+  const samplingStrategy = samplingStrategyProps.strategy;
 
   return (
     <OuterWrapper>
@@ -36,7 +37,7 @@ export const App = () => {
           </LoginWrapper>
         </Route>
         <Route path='/explore/:country'>
-          <ExploreFocusSplit />
+          <ExploreFocusSplit samplingStrategy={samplingStrategy} />
         </Route>
         <Route path='/global-samples'>
           <ScrollableFullContentWrapper>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,8 @@ import { GlobalSamplePage } from './pages/GlobalSamplePage';
 import { useSamplingStrategy } from './components/HeaderSamplingStrategySelect';
 
 export const App = () => {
+  // TODO
   const samplingStrategyProps = useSamplingStrategy();
-  const samplingStrategy = samplingStrategyProps.strategy;
 
   return (
     <OuterWrapper>
@@ -36,8 +36,8 @@ export const App = () => {
             <LoginPage />
           </LoginWrapper>
         </Route>
-        <Route path='/explore/:country'>
-          <ExploreFocusSplit samplingStrategy={samplingStrategy} />
+        <Route path='/explore/:country/:samplingStrategy'>
+          <ExploreFocusSplit />
         </Route>
         <Route path='/global-samples'>
           <ScrollableFullContentWrapper>

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -37,7 +37,7 @@ export const Header = ({ samplingStrategyProps }: Props) => {
         <Nav className='ml-4 mr-auto'>
           <HeaderCountrySelect />
           <HeaderSamplingStrategySelect {...samplingStrategyProps} />
-          <Nav.Link href='/about' style={{ marginLeft: '20px', textDecoration: 'underline' }}>
+          <Nav.Link href='/about' style={{ textDecoration: 'underline' }}>
             What is this website?
           </Nav.Link>
         </Nav>

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -2,17 +2,10 @@ import React from 'react';
 import { Nav, Navbar } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { HeaderCountrySelect } from './components/HeaderCountrySelect';
-import {
-  HeaderSamplingStrategySelect,
-  Props as HeaderSamplingStrategySelectProps,
-} from './components/HeaderSamplingStrategySelect';
+import { HeaderSamplingStrategySelect } from './components/HeaderSamplingStrategySelect';
 import { AccountService } from './services/AccountService';
 
-interface Props {
-  samplingStrategyProps: HeaderSamplingStrategySelectProps;
-}
-
-export const Header = ({ samplingStrategyProps }: Props) => {
+export const Header = () => {
   const loggedIn = AccountService.isLoggedIn();
   let username = null;
   if (loggedIn) {
@@ -36,7 +29,7 @@ export const Header = ({ samplingStrategyProps }: Props) => {
       <Navbar.Collapse>
         <Nav className='ml-4 mr-auto'>
           <HeaderCountrySelect />
-          <HeaderSamplingStrategySelect {...samplingStrategyProps} />
+          <HeaderSamplingStrategySelect />
           <Nav.Link href='/about' style={{ textDecoration: 'underline' }}>
             What is this website?
           </Nav.Link>

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -2,9 +2,17 @@ import React from 'react';
 import { Nav, Navbar } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { HeaderCountrySelect } from './components/HeaderCountrySelect';
+import {
+  HeaderSamplingStrategySelect,
+  Props as HeaderSamplingStrategySelectProps,
+} from './components/HeaderSamplingStrategySelect';
 import { AccountService } from './services/AccountService';
 
-export const Header = () => {
+interface Props {
+  samplingStrategyProps: HeaderSamplingStrategySelectProps;
+}
+
+export const Header = ({ samplingStrategyProps }: Props) => {
   const loggedIn = AccountService.isLoggedIn();
   let username = null;
   if (loggedIn) {
@@ -28,6 +36,7 @@ export const Header = () => {
       <Navbar.Collapse>
         <Nav className='ml-4 mr-auto'>
           <HeaderCountrySelect />
+          <HeaderSamplingStrategySelect {...samplingStrategyProps} />
           <Nav.Link href='/about' style={{ marginLeft: '20px', textDecoration: 'underline' }}>
             What is this website?
           </Nav.Link>

--- a/src/components/FocusVariantHeaderControls.tsx
+++ b/src/components/FocusVariantHeaderControls.tsx
@@ -55,7 +55,7 @@ export const FocusVariantHeaderControls = ({
         </OverlayTrigger>
       )}
       <LazySampleButton
-        query={{ variantSelector: { variant, matchPercentage }, country }}
+        query={{ variantSelector: { variant, matchPercentage }, country, samplingStrategy }}
         variant='outline-dark'
         size='sm'
       >

--- a/src/components/FocusVariantHeaderControls.tsx
+++ b/src/components/FocusVariantHeaderControls.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { AccountService } from '../services/AccountService';
+import { SamplingStrategy, toLiteralSamplingStrategy } from '../services/api';
 import { Country, Variant } from '../services/api-types';
 import { NextcladeService } from '../services/NextcladeService';
 import { LazySampleButton } from './LazySampleButton';
@@ -9,12 +10,25 @@ export interface Props {
   country: Country;
   matchPercentage: number;
   variant: Variant;
+  samplingStrategy: SamplingStrategy;
 }
 
-export const FocusVariantHeaderControls = ({ country, matchPercentage, variant }: Props) => {
+export const FocusVariantHeaderControls = ({
+  country,
+  matchPercentage,
+  variant,
+  samplingStrategy,
+}: Props) => {
   const nextcladeButton = (
     <Button
-      onClick={() => NextcladeService.showVariantOnNextclade(variant, matchPercentage, country)}
+      onClick={() =>
+        NextcladeService.showVariantOnNextclade({
+          variant,
+          matchPercentage,
+          country,
+          samplingStrategy: toLiteralSamplingStrategy(samplingStrategy),
+        })
+      }
       variant='outline-dark'
       size='sm'
       className='mr-2'

--- a/src/components/HeaderCountrySelect.tsx
+++ b/src/components/HeaderCountrySelect.tsx
@@ -27,7 +27,7 @@ export const HeaderCountrySelect = () => {
 
   return (
     <Route path='/explore'>
-      <Form inline>
+      <Form inline className='mr-3'>
         <Form.Label htmlFor='countrySelect' className='mr-2'>
           Country
         </Form.Label>

--- a/src/components/HeaderCountrySelect.tsx
+++ b/src/components/HeaderCountrySelect.tsx
@@ -1,42 +1,25 @@
 import React from 'react';
 import { Form } from 'react-bootstrap';
-import { generatePath, Route, useHistory, useLocation, useRouteMatch } from 'react-router-dom';
-import { Country } from '../services/api-types';
+import { useExploreUrl } from '../helpers/explore-url';
 import { RequiredCountrySelect } from './RequiredCountrySelect';
 
 export const HeaderCountrySelect = () => {
-  const match = useRouteMatch<{ country: string }>('/explore/:country');
-  const location = useLocation();
-  const history = useHistory();
+  const exploreUrl = useExploreUrl();
 
-  if (!match) {
+  if (!exploreUrl) {
     return null;
   }
-
-  if (!location.pathname.startsWith(match.url)) {
-    console.error(`match.url (${match.url}) is not a prefix of location.pathname (${location.pathname})`);
-    return null;
-  }
-
-  const onCountrySelect = (country: Country) => {
-    history.push({
-      ...location,
-      pathname: generatePath(match.path, { country }) + location.pathname.slice(match.url.length),
-    });
-  };
 
   return (
-    <Route path='/explore'>
-      <Form inline className='mr-3'>
-        <Form.Label htmlFor='countrySelect' className='mr-2'>
-          Country
-        </Form.Label>
-        <RequiredCountrySelect
-          id='countrySelect'
-          selected={match.params.country}
-          onSelect={onCountrySelect}
-        />
-      </Form>
-    </Route>
+    <Form inline className='mr-3'>
+      <Form.Label htmlFor='countrySelect' className='mr-2'>
+        Country
+      </Form.Label>
+      <RequiredCountrySelect
+        id='countrySelect'
+        selected={exploreUrl.country}
+        onSelect={exploreUrl.setCountry}
+      />
+    </Form>
   );
 };

--- a/src/components/HeaderSamplingStrategySelect.tsx
+++ b/src/components/HeaderSamplingStrategySelect.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Form } from 'react-bootstrap';
 import { useRouteMatch } from 'react-router-dom';
 import { AccountService } from '../services/AccountService';
 import { SamplingStrategy } from '../services/api';
@@ -39,5 +40,15 @@ export const HeaderSamplingStrategySelect = ({ strategy, onStrategyChange, locke
     return null;
   }
 
-  return <div>{strategy}</div>;
+  return (
+    <Form inline className='mr-3'>
+      <Form.Label htmlFor='samplingStrategySelect' className='mr-2'>
+        Sampling strategy
+      </Form.Label>
+      <Form.Control as='select' custom id='samplingStrategySelect' value={strategy} disabled={!!locked}>
+        <option value={SamplingStrategy.AllSamples}>All samples</option>
+        <option value={SamplingStrategy.Surveillance}>Surveillance</option>
+      </Form.Control>
+    </Form>
+  );
 };

--- a/src/components/HeaderSamplingStrategySelect.tsx
+++ b/src/components/HeaderSamplingStrategySelect.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { Form } from 'react-bootstrap';
+import { Form, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useRouteMatch } from 'react-router-dom';
 import { SamplingStrategy } from '../services/api';
 import { unreachable } from '../helpers/unreachable';
+import { OverlayInjectedProps, OverlayTriggerRenderProps } from 'react-bootstrap/esm/OverlayTrigger';
 
 enum LockReason {
   ScreenNotSupported = 'ScreenNotSupported',
@@ -42,22 +43,39 @@ export const HeaderSamplingStrategySelect = ({ strategy, onStrategyChange, locke
     return unreachable(locked);
   }
 
-  return (
+  const makeForm = ({ ref, ...props }: Partial<OverlayTriggerRenderProps>) => (
     <Form inline className='mr-3'>
       <Form.Label htmlFor='samplingStrategySelect' className='mr-2'>
         Sampling strategy
       </Form.Label>
-      <Form.Control
-        as='select'
-        custom
-        id='samplingStrategySelect'
-        value={strategy}
-        onChange={ev => onStrategyChange(ev.target.value as SamplingStrategy)}
-        disabled={!!locked}
-      >
-        <option value={SamplingStrategy.AllSamples}>All samples</option>
-        <option value={SamplingStrategy.Surveillance}>Surveillance</option>
-      </Form.Control>
+      <div {...props} ref={ref}>
+        <Form.Control
+          as='select'
+          custom
+          id='samplingStrategySelect'
+          value={strategy}
+          onChange={ev => onStrategyChange(ev.target.value as SamplingStrategy)}
+          disabled={!!locked}
+          style={locked ? { pointerEvents: 'none' } : undefined}
+        >
+          <option value={SamplingStrategy.AllSamples}>All samples</option>
+          <option value={SamplingStrategy.Surveillance}>Surveillance</option>
+        </Form.Control>
+      </div>
     </Form>
+  );
+
+  const tooltip = (
+    <Tooltip id='samplingStrategyDisabledTooltip'>
+      Filtering for surveillance samples is only supported for Switzerland.
+    </Tooltip>
+  );
+
+  return locked ? (
+    <OverlayTrigger placement='bottom' overlay={tooltip}>
+      {makeForm}
+    </OverlayTrigger>
+  ) : (
+    makeForm({})
   );
 };

--- a/src/components/HeaderSamplingStrategySelect.tsx
+++ b/src/components/HeaderSamplingStrategySelect.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { useRouteMatch } from 'react-router-dom';
+import { AccountService } from '../services/AccountService';
+import { SamplingStrategy } from '../services/api';
+
+enum LockReason {
+  PrivateLoginRequired = 'PrivateLoginRequired',
+  NotSupportedByScreen = 'NotSupportedByScreen',
+}
+
+export interface Props {
+  strategy: SamplingStrategy;
+  locked?: LockReason;
+  onStrategyChange: (strategy: SamplingStrategy) => void;
+}
+
+const supportedUrls = ['/explore', '/global-samples'];
+
+export function useSamplingStrategy(): Props {
+  const isSupported = !!useRouteMatch(supportedUrls);
+  const isLoggedIn = AccountService.isLoggedIn();
+
+  const locked =
+    (!isSupported && LockReason.NotSupportedByScreen) ||
+    (!isLoggedIn && LockReason.PrivateLoginRequired) ||
+    undefined;
+
+  const [preferredStrategy, setPreferredStrategy] = useState(SamplingStrategy.AllSamples);
+
+  return {
+    strategy: locked ? SamplingStrategy.AllSamples : preferredStrategy,
+    locked,
+    onStrategyChange: setPreferredStrategy,
+  };
+}
+
+export const HeaderSamplingStrategySelect = ({ strategy, onStrategyChange, locked }: Props) => {
+  if (locked === LockReason.NotSupportedByScreen) {
+    return null;
+  }
+
+  return <div>{strategy}</div>;
+};

--- a/src/components/HeaderSamplingStrategySelect.tsx
+++ b/src/components/HeaderSamplingStrategySelect.tsx
@@ -1,47 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Form, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { OverlayTriggerRenderProps } from 'react-bootstrap/esm/OverlayTrigger';
-import { useRouteMatch } from 'react-router-dom';
-import { unreachable } from '../helpers/unreachable';
+import { useExploreUrl } from '../helpers/explore-url';
 import { SamplingStrategy } from '../services/api';
 
-enum LockReason {
-  ScreenNotSupported = 'ScreenNotSupported',
-  CountryNotSupported = 'CountryNotSupported',
-}
+export const HeaderSamplingStrategySelect = () => {
+  const exploreUrl = useExploreUrl();
 
-export interface Props {
-  strategy: SamplingStrategy;
-  locked?: LockReason;
-  onStrategyChange: (strategy: SamplingStrategy) => void;
-}
-
-export function useSamplingStrategy(): Props {
-  const match = useRouteMatch<{ country: string }>('/explore/:country');
-
-  const screenIsSupported = !!match;
-  const countryIsSupported = match?.params.country === 'Switzerland';
-
-  const locked =
-    (!screenIsSupported && LockReason.ScreenNotSupported) ||
-    (!countryIsSupported && LockReason.CountryNotSupported) ||
-    undefined;
-
-  const [preferredStrategy, setPreferredStrategy] = useState(SamplingStrategy.AllSamples);
-
-  return {
-    strategy: locked ? SamplingStrategy.AllSamples : preferredStrategy,
-    locked,
-    onStrategyChange: setPreferredStrategy,
-  };
-}
-
-export const HeaderSamplingStrategySelect = ({ strategy, onStrategyChange, locked }: Props) => {
-  if (locked === LockReason.ScreenNotSupported) {
+  if (!exploreUrl) {
     return null;
-  } else if (locked && locked !== LockReason.CountryNotSupported) {
-    return unreachable(locked);
   }
+
+  const locked = exploreUrl.country !== 'Switzerland';
 
   const makeForm = ({ ref, ...props }: Partial<OverlayTriggerRenderProps>) => (
     <Form inline className='mr-3'>
@@ -53,8 +23,8 @@ export const HeaderSamplingStrategySelect = ({ strategy, onStrategyChange, locke
           as='select'
           custom
           id='samplingStrategySelect'
-          value={strategy}
-          onChange={ev => onStrategyChange(ev.target.value as SamplingStrategy)}
+          value={exploreUrl.samplingStrategy}
+          onChange={ev => exploreUrl.setSamplingStrategy(ev.target.value as SamplingStrategy)}
           disabled={!!locked}
           style={locked ? { pointerEvents: 'none' } : undefined}
         >

--- a/src/components/HeaderSamplingStrategySelect.tsx
+++ b/src/components/HeaderSamplingStrategySelect.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Form, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { OverlayTriggerRenderProps } from 'react-bootstrap/esm/OverlayTrigger';
 import { useRouteMatch } from 'react-router-dom';
-import { SamplingStrategy } from '../services/api';
 import { unreachable } from '../helpers/unreachable';
-import { OverlayInjectedProps, OverlayTriggerRenderProps } from 'react-bootstrap/esm/OverlayTrigger';
+import { SamplingStrategy } from '../services/api';
 
 enum LockReason {
   ScreenNotSupported = 'ScreenNotSupported',

--- a/src/components/InternationalComparison.tsx
+++ b/src/components/InternationalComparison.tsx
@@ -132,7 +132,11 @@ export const InternationalComparison = ({
               </Button>
             )}
             <LazySampleButton
-              query={{ variantSelector: { variant, matchPercentage }, country: undefined }}
+              query={{
+                variantSelector: { variant, matchPercentage },
+                country: undefined,
+                samplingStrategy: SamplingStrategy.AllSamples,
+              }}
               variant='outline-primary'
               size='sm'
               className='ml-1'
@@ -182,7 +186,11 @@ export const InternationalComparison = ({
                         </Button>
                       )}
                       <LazySampleButton
-                        query={{ variantSelector: { variant, matchPercentage }, country: c.country }}
+                        query={{
+                          variantSelector: { variant, matchPercentage },
+                          country: c.country,
+                          samplingStrategy: SamplingStrategy.AllSamples,
+                        }}
                         variant='outline-dark'
                         size='sm'
                       >

--- a/src/components/InternationalComparison.tsx
+++ b/src/components/InternationalComparison.tsx
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { Button } from 'react-bootstrap';
 import Table from 'react-bootstrap/Table';
 import { AccountService } from '../services/AccountService';
-import { DistributionType, getVariantDistributionData } from '../services/api';
+import {
+  DistributionType,
+  getVariantDistributionData,
+  SamplingStrategy,
+  toLiteralSamplingStrategy,
+} from '../services/api';
 import { Country, InternationalTimeDistributionEntry, Variant } from '../services/api-types';
 import { NextcladeService } from '../services/NextcladeService';
 import { Utils } from '../services/Utils';
@@ -100,7 +105,14 @@ export const InternationalComparison = ({ country, matchPercentage, variant }: P
                 variant='outline-primary'
                 size='sm'
                 className='ml-1'
-                onClick={() => NextcladeService.showVariantOnNextclade(variant, matchPercentage, undefined)}
+                onClick={() =>
+                  NextcladeService.showVariantOnNextclade({
+                    variant,
+                    matchPercentage,
+                    country: undefined,
+                    samplingStrategy: toLiteralSamplingStrategy(SamplingStrategy.AllSamples),
+                  })
+                }
               >
                 Show on Nextclade
               </Button>
@@ -141,7 +153,12 @@ export const InternationalComparison = ({ country, matchPercentage, variant }: P
                       {AccountService.isLoggedIn() && (
                         <Button
                           onClick={() =>
-                            NextcladeService.showVariantOnNextclade(variant, matchPercentage, c.country)
+                            NextcladeService.showVariantOnNextclade({
+                              variant,
+                              matchPercentage,
+                              country: c.country,
+                              samplingStrategy: toLiteralSamplingStrategy(SamplingStrategy.AllSamples),
+                            })
                           }
                           variant='outline-dark'
                           size='sm'

--- a/src/components/InternationalComparison.tsx
+++ b/src/components/InternationalComparison.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button } from 'react-bootstrap';
+import { Alert, Button } from 'react-bootstrap';
 import Table from 'react-bootstrap/Table';
 import { AccountService } from '../services/AccountService';
 import {
@@ -18,9 +18,10 @@ interface Props {
   country: Country;
   matchPercentage: number;
   variant: Variant;
+  samplingStrategy: SamplingStrategy;
 }
 
-export const InternationalComparison = ({ country, matchPercentage, variant }: Props) => {
+export const InternationalComparison = ({ country, matchPercentage, variant, samplingStrategy }: Props) => {
   const [distribution, setDistribution] = useState<InternationalTimeDistributionEntry[] | null>(null);
   const [logScale, setLogScale] = useState<boolean>(false);
 
@@ -89,6 +90,13 @@ export const InternationalComparison = ({ country, matchPercentage, variant }: P
 
   return (
     <>
+      {samplingStrategy !== SamplingStrategy.AllSamples && (
+        <Alert variant='warning'>
+          The selected sampling strategy can not be used for international comparison. Showing all samples
+          instead.
+        </Alert>
+      )}
+
       <VariantInternationalComparisonPlotWidget.ShareableComponent
         height={500}
         country={country}

--- a/src/components/InternationalComparison.tsx
+++ b/src/components/InternationalComparison.tsx
@@ -21,7 +21,12 @@ interface Props {
   samplingStrategy: SamplingStrategy;
 }
 
-export const InternationalComparison = ({ country, matchPercentage, variant, samplingStrategy }: Props) => {
+export const InternationalComparison = ({
+  country,
+  matchPercentage,
+  variant,
+  samplingStrategy: requestedSamplingStrategy,
+}: Props) => {
   const [distribution, setDistribution] = useState<InternationalTimeDistributionEntry[] | null>(null);
   const [logScale, setLogScale] = useState<boolean>(false);
 
@@ -35,6 +40,7 @@ export const InternationalComparison = ({ country, matchPercentage, variant, sam
         country: undefined,
         mutations: variant.mutations,
         matchPercentage,
+        samplingStrategy: toLiteralSamplingStrategy(SamplingStrategy.AllSamples),
       },
       signal
     ).then(newDistributionData => {
@@ -90,7 +96,7 @@ export const InternationalComparison = ({ country, matchPercentage, variant, sam
 
   return (
     <>
-      {samplingStrategy !== SamplingStrategy.AllSamples && (
+      {requestedSamplingStrategy !== SamplingStrategy.AllSamples && (
         <Alert variant='warning'>
           The selected sampling strategy can not be used for international comparison. Showing all samples
           instead.

--- a/src/components/LazySampleButton.tsx
+++ b/src/components/LazySampleButton.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { Button, ButtonProps } from 'react-bootstrap';
 import { useHistory } from 'react-router-dom';
+import { getFocusPageLink } from '../helpers/explore-url';
 import { VariantSelector } from '../helpers/sample-selector';
-import { getFocusPageLink } from '../pages/ExploreFocusSplit';
 import { getGlobalSamplePageLink } from '../pages/GlobalSamplePage';
+import { SamplingStrategy } from '../services/api';
 import { Country } from '../services/api-types';
 
 interface Props extends ButtonProps {
   query: {
     variantSelector: VariantSelector;
+    samplingStrategy: SamplingStrategy;
     country: Country | undefined;
   };
 }
 
 export const LazySampleButton = ({
-  query: { variantSelector, country },
+  query: { variantSelector, country, samplingStrategy },
   onClick: onClickFromProps,
   ...buttonProps
 }: Props) => {
@@ -24,7 +26,9 @@ export const LazySampleButton = ({
       {...buttonProps}
       onClick={ev => {
         if (country) {
-          history.push(getFocusPageLink(variantSelector, country, '/samples'));
+          history.push(
+            getFocusPageLink({ variantSelector, country, samplingStrategy, deepFocusPath: '/samples' })
+          );
         } else {
           history.push(getGlobalSamplePageLink(variantSelector));
         }

--- a/src/components/SampleTable.tsx
+++ b/src/components/SampleTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Overlay, Popover, Table } from 'react-bootstrap';
-import { getSamples } from '../services/api';
+import { getSamples, SamplingStrategy, toLiteralSamplingStrategy } from '../services/api';
 import { Country, Sample, Variant } from '../services/api-types';
 import { MutationList } from './MutationList';
 
@@ -54,10 +54,11 @@ interface Props {
   matchPercentage: number;
   variant: Variant;
   country?: Country;
+  samplingStrategy: SamplingStrategy;
 }
 
 // SampleTable shows detailed information about individual samples from GISAID
-export const SampleTable = ({ matchPercentage, variant, country }: Props) => {
+export const SampleTable = ({ matchPercentage, variant, country, samplingStrategy }: Props) => {
   const [samples, setSamples] = useState<Sample[] | undefined>(undefined);
   const [totalNumber, setTotalNumber] = useState<number | undefined>(undefined);
 
@@ -73,6 +74,7 @@ export const SampleTable = ({ matchPercentage, variant, country }: Props) => {
         mutationsString,
         matchPercentage,
         country,
+        samplingStrategy: toLiteralSamplingStrategy(samplingStrategy),
       },
       signal
     ).then(response => {
@@ -86,7 +88,7 @@ export const SampleTable = ({ matchPercentage, variant, country }: Props) => {
       isSubscribed = false;
       controller.abort();
     };
-  }, [matchPercentage, variant.mutations, country]);
+  }, [matchPercentage, variant.mutations, country, samplingStrategy]);
 
   const [popoverTarget, setPopoverTarget] = useState<PopoverTarget>();
   useEffect(() => {

--- a/src/components/Switzerland/index.tsx
+++ b/src/components/Switzerland/index.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { DistributionType, getVariantDistributionData } from '../../services/api';
-import { TimeZipCodeDistributionEntry } from '../../services/api-types';
-import { AccountService } from '../../services/AccountService';
-import * as zod from 'zod';
-import { SampleSelectorSchema } from '../../helpers/sample-selector';
 import { useResizeDetector } from 'react-resize-detector';
 import styled from 'styled-components';
-
+import * as zod from 'zod';
+import { SampleSelectorSchema } from '../../helpers/sample-selector';
+import { AccountService } from '../../services/AccountService';
+import { DistributionType, getVariantDistributionData } from '../../services/api';
+import { TimeZipCodeDistributionEntry } from '../../services/api-types';
 import Map from './Map';
 
 const MAP_SIDE_PADDING = 2;
@@ -18,7 +17,7 @@ const MapWrapper = styled.div`
 const PropsSchema = SampleSelectorSchema;
 type Props = zod.infer<typeof PropsSchema>;
 
-const Switzerland = ({ country, mutations, matchPercentage }: Props) => {
+const Switzerland = ({ country, mutations, matchPercentage, samplingStrategy }: Props) => {
   const [distributionData, setDistributionData] = useState<TimeZipCodeDistributionEntry[]>([]);
   const loggedIn = AccountService.isLoggedIn();
   const { width, ref } = useResizeDetector();
@@ -33,6 +32,7 @@ const Switzerland = ({ country, mutations, matchPercentage }: Props) => {
         country,
         mutations,
         matchPercentage,
+        samplingStrategy,
       },
       signal
     )
@@ -48,7 +48,7 @@ const Switzerland = ({ country, mutations, matchPercentage }: Props) => {
       isSubscribed = false;
       controller.abort();
     };
-  }, [country, mutations, matchPercentage]);
+  }, [country, mutations, matchPercentage, samplingStrategy]);
 
   return loggedIn && distributionData !== undefined ? (
     <>

--- a/src/helpers/__tests__/explore-url.test.tsx
+++ b/src/helpers/__tests__/explore-url.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { SamplingStrategy } from '../../services/api';
+import { ExploreUrl, useExploreUrl } from '../explore-url';
+import { VariantSelector } from '../sample-selector';
+import { pick } from 'lodash';
+
+let container: HTMLDivElement | undefined;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  if (container) {
+    unmountComponentAtNode(container);
+    container.remove();
+    container = undefined;
+  }
+});
+
+describe('useExploreUrl', () => {
+  const exampleVariantSelector: VariantSelector = {
+    variant: { name: 'Test variant', mutations: ['ORF8:Q27*'] },
+    matchPercentage: 0.7,
+  };
+  const exampleVariantSelectorEncoded = JSON.stringify(exampleVariantSelector);
+
+  interface Case {
+    label: string;
+    initialUrl: string;
+    finalUrl?: string; // defaults to initialUrl
+    exploreUrl?: {
+      country: string;
+      samplingStrategy: SamplingStrategy;
+      variantSelector?: VariantSelector;
+    };
+    warnings?: RegExp[];
+  }
+  const cases: Case[] = [
+    {
+      label: 'does nothing at root URL',
+      initialUrl: '/',
+    },
+    {
+      label: 'does nothing at non-explore URL',
+      initialUrl: '/some-url',
+    },
+    {
+      label: 'redirects home without country',
+      initialUrl: '/explore/',
+      finalUrl: '/',
+      warnings: [/invalid URL/],
+    },
+    {
+      label: 'accepts explore URL with no focused variant',
+      initialUrl: '/explore/Germany/Surveillance',
+      exploreUrl: {
+        country: 'Germany',
+        samplingStrategy: SamplingStrategy.Surveillance,
+      },
+    },
+    {
+      label: 'redirects from old URL (no focused variant, no trailing slash)',
+      initialUrl: '/explore/Germany/variants',
+      finalUrl: '/explore/Germany/AllSamples/variants',
+      exploreUrl: {
+        country: 'Germany',
+        samplingStrategy: SamplingStrategy.AllSamples,
+      },
+      warnings: [/invalid samplingStrategy/],
+    },
+    {
+      label: 'redirects from old URL (no focused variant, trailing slash)',
+      initialUrl: '/explore/Germany/variants/',
+      finalUrl: '/explore/Germany/AllSamples/variants/',
+      exploreUrl: {
+        country: 'Germany',
+        samplingStrategy: SamplingStrategy.AllSamples,
+      },
+      warnings: [/invalid samplingStrategy/],
+    },
+    {
+      label: 'redirects from old URL (focused variant)',
+      initialUrl: `/explore/Germany/variants/json=${exampleVariantSelectorEncoded}`,
+      finalUrl: `/explore/Germany/AllSamples/variants/json=${exampleVariantSelectorEncoded}`,
+      exploreUrl: {
+        country: 'Germany',
+        samplingStrategy: SamplingStrategy.AllSamples,
+        variantSelector: exampleVariantSelector,
+      },
+      warnings: [/invalid samplingStrategy/],
+    },
+    {
+      label: 'redirects from old URL (focused variant, deep focus)',
+      initialUrl: `/explore/Germany/variants/json=${exampleVariantSelectorEncoded}/deepExample`,
+      finalUrl: `/explore/Germany/AllSamples/variants/json=${exampleVariantSelectorEncoded}/deepExample`,
+      exploreUrl: {
+        country: 'Germany',
+        samplingStrategy: SamplingStrategy.AllSamples,
+        variantSelector: exampleVariantSelector,
+      },
+      warnings: [/invalid samplingStrategy/],
+    },
+    {
+      label: 'decodes variant',
+      initialUrl: `/explore/Italy/Surveillance/variants/json=${exampleVariantSelectorEncoded}`,
+      exploreUrl: {
+        country: 'Italy',
+        samplingStrategy: SamplingStrategy.Surveillance,
+        variantSelector: exampleVariantSelector,
+      },
+    },
+    {
+      label: 'gives warning with invalid encoded variant',
+      initialUrl: `/explore/Italy/Surveillance/variants/json=bla`,
+      exploreUrl: {
+        country: 'Italy',
+        samplingStrategy: SamplingStrategy.Surveillance,
+      },
+      warnings: [/could not decode/],
+    },
+  ];
+
+  for (const c of cases) {
+    // eslint-disable-next-line jest/valid-title, no-loop-func
+    test(c.label, () => {
+      const warnings: unknown[] = [];
+      for (const method of ['log', 'warn', 'error'] as const) {
+        jest.spyOn(console, method).mockImplementation((...args) => {
+          warnings.push(args[0]);
+        });
+      }
+
+      let actualExploreUrl: ExploreUrl | undefined;
+      let actualFinalUrl: string | undefined;
+      let renderCount = 0;
+      act(() => {
+        render(
+          <MemoryRouter initialEntries={[c.initialUrl]}>
+            {React.createElement(() => {
+              renderCount++;
+              if (renderCount > 10) {
+                jest.restoreAllMocks();
+                console.log(warnings);
+                throw new Error('reached max number of renders');
+              }
+
+              actualExploreUrl = useExploreUrl();
+              actualFinalUrl = useLocation().pathname;
+
+              return null;
+            })}
+          </MemoryRouter>,
+          container!
+        );
+      });
+
+      jest.restoreAllMocks();
+
+      expect(actualFinalUrl).toEqual(c.finalUrl ?? c.initialUrl);
+
+      const relevantKeys = ['country', 'samplingStrategy', 'variantSelector'] as const;
+      expect(actualExploreUrl && pick(actualExploreUrl, relevantKeys)).toEqual(
+        c.exploreUrl && pick(c.exploreUrl, relevantKeys)
+      );
+
+      if (warnings.length !== (c.warnings ?? []).length) {
+        console.log(warnings);
+      }
+      expect(warnings.length).toEqual((c.warnings ?? []).length);
+      for (const [i, expectedWarning] of (c.warnings ?? []).entries()) {
+        expect(warnings[i]).toMatch(expectedWarning);
+      }
+    });
+  }
+});

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -8,7 +8,7 @@ import { Country } from '../services/api-types';
 
 const queryEncoder = new ZodQueryEncoder(VariantSelectorSchema);
 
-interface ExploreUrl {
+export interface ExploreUrl {
   country: Country;
   setCountry: (country: string) => void;
   samplingStrategy: SamplingStrategy;
@@ -33,7 +33,10 @@ export function useExploreUrl(): ExploreUrl | undefined {
   const samplingStrategy = baseRouteMatch?.params.samplingStrategy;
   useEffect(() => {
     if (!baseRouteMatch) {
-      if (location.pathname.startsWith('/explore/')) {
+      if (location.pathname.startsWith('/explore/') && !location.pathname.endsWith('/variants')) {
+        // This is probably an old URL with no focused variant
+        history.push(location.pathname.replace(/\/$/, '') + '/variants');
+      } else if (location.pathname.startsWith('/explore/')) {
         // We can't redirect anywhere better without the information from baseRouteMatch
         console.warn('invalid URL - redirecting home', location.pathname);
         history.push('/');
@@ -42,10 +45,10 @@ export function useExploreUrl(): ExploreUrl | undefined {
       }
     } else if (samplingStrategy === 'variants') {
       // Redirect from our old URL style
-      const prefix = `/explore/${baseRouteMatch.params.country}`;
+      const prefix = `/explore/${baseRouteMatch.params.country}/`;
       assert(location.pathname.startsWith(prefix));
       const suffix = location.pathname.slice(prefix.length);
-      history.push(`${prefix}${SamplingStrategy.AllSamples}${suffix}`);
+      history.push(`${prefix}${SamplingStrategy.AllSamples}/${suffix}`);
     } else if (typeof samplingStrategy === 'string' && !isSamplingStrategy(samplingStrategy)) {
       // Better to show all samples then to show a blank page
       const oldPrefix = `/explore/${baseRouteMatch.params.country}/${samplingStrategy}`;

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -28,10 +28,6 @@ export function useExploreUrl(): ExploreUrl | undefined {
     variantSelector: string;
   }>(`/explore/:country/:samplingStrategy/variants/:variantSelector`);
 
-  console.log('DEBUG location', location);
-  console.log('DEBUG baseRouteMatch', baseRouteMatch);
-  console.log('DEBUG variantRouteMatch', variantRouteMatch);
-
   const samplingStrategy = baseRouteMatch?.params.samplingStrategy;
   useEffect(() => {
     if (!baseRouteMatch) {

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -1,0 +1,107 @@
+import assert from 'assert';
+import { useEffect, useMemo } from 'react';
+import { generatePath, useHistory, useLocation, useRouteMatch } from 'react-router';
+import { ZodQueryEncoder } from '../helpers/query-encoder';
+import { VariantSelector, VariantSelectorSchema } from '../helpers/sample-selector';
+import { isSamplingStrategy, SamplingStrategy } from '../services/api';
+import { Country } from '../services/api-types';
+
+const queryEncoder = new ZodQueryEncoder(VariantSelectorSchema);
+
+interface ExploreUrl {
+  country: Country;
+  samplingStrategy: SamplingStrategy;
+  variantSelector?: VariantSelector;
+  focusKey: string;
+}
+
+export function useExploreUrl(): ExploreUrl | undefined {
+  const history = useHistory();
+  const location = useLocation();
+
+  const baseRouteMatch = useRouteMatch<{ country: string; samplingStrategy: string }>(
+    `/explore/:country/:samplingStrategy`
+  );
+  const variantRouteMatch = useRouteMatch<{
+    country: string;
+    samplingStrategy: string;
+    variantSelector: string;
+  }>(`/explore/:country/:samplingStrategy/variants/:variantSelector`);
+
+  console.log('DEBUG location', location);
+  console.log('DEBUG baseRouteMatch', baseRouteMatch);
+  console.log('DEBUG variantRouteMatch', variantRouteMatch);
+
+  const samplingStrategy = baseRouteMatch?.params.samplingStrategy;
+  useEffect(() => {
+    if (!baseRouteMatch) {
+      // We can't redirect anywhere better without the information from baseRouteMatch
+      history.push('/');
+    } else if (samplingStrategy === 'variants') {
+      // Redirect from our old URL style
+      const prefix = `/explore/${baseRouteMatch.params.country}/`;
+      assert(location.pathname.startsWith(prefix));
+      const suffix = location.pathname.slice(prefix.length);
+      history.push(`${prefix}${SamplingStrategy.AllSamples}/${suffix}`);
+    } else if (typeof samplingStrategy === 'string' && !isSamplingStrategy(samplingStrategy)) {
+      // Better to show all samples then to show a blank page
+      const oldPrefix = `/explore/${baseRouteMatch.params.country}/${samplingStrategy}/`;
+      assert(location.pathname.startsWith(oldPrefix));
+      const suffix = location.pathname.slice(oldPrefix.length);
+      history.push(`/explore/${baseRouteMatch.params.country}/${SamplingStrategy.AllSamples}/${suffix}`);
+    }
+  }, [location.pathname, baseRouteMatch, history, samplingStrategy]);
+
+  const encodedVariantSelector = variantRouteMatch?.params.variantSelector;
+  const variantSelector = useMemo(() => {
+    try {
+      if (encodedVariantSelector) {
+        return queryEncoder.decode(new URLSearchParams(encodedVariantSelector));
+      }
+    } catch (err) {
+      console.error('could not decode variant selector', encodedVariantSelector);
+    }
+  }, [encodedVariantSelector]);
+
+  if (!baseRouteMatch) {
+    return undefined;
+  }
+
+  if (!samplingStrategy || !isSamplingStrategy(samplingStrategy)) {
+    console.error('invalid samplingStrategy in URL', samplingStrategy);
+    // The useEffect above will attempt to recover from this
+    return undefined;
+  }
+
+  if (variantRouteMatch) {
+    assert.strictEqual(baseRouteMatch.params.country, variantRouteMatch.params.country);
+    assert.strictEqual(baseRouteMatch.params.samplingStrategy, variantRouteMatch.params.samplingStrategy);
+  }
+
+  const country = baseRouteMatch.params.country;
+
+  return {
+    country,
+    samplingStrategy,
+    variantSelector,
+    focusKey: `${country}-${samplingStrategy}-${variantSelector}`,
+  };
+}
+
+export function getFocusPageLink({
+  variantSelector,
+  country,
+  samplingStrategy,
+  deepFocusPath = '',
+}: {
+  variantSelector: VariantSelector;
+  country: Country;
+  samplingStrategy: SamplingStrategy;
+  deepFocusPath?: string;
+}) {
+  return (
+    generatePath(`/explore/${country}/${samplingStrategy}/variants/:variantSelector`, {
+      variantSelector: queryEncoder.encode(variantSelector).toString(),
+    }) + deepFocusPath
+  );
+}

--- a/src/helpers/sample-selector.ts
+++ b/src/helpers/sample-selector.ts
@@ -1,5 +1,6 @@
 import { CountrySchema, VariantSchema } from '../services/api-types';
 import * as zod from 'zod';
+import { LiteralSamplingStrategySchema } from '../services/api';
 
 export const VariantSelectorSchema = zod.object({
   variant: VariantSchema,
@@ -10,6 +11,7 @@ export const SampleSelectorSchema = zod.object({
   country: CountrySchema,
   matchPercentage: zod.number(),
   mutations: zod.array(zod.string()),
+  samplingStrategy: LiteralSamplingStrategySchema,
 });
 
 export type VariantSelector = zod.infer<typeof VariantSelectorSchema>;

--- a/src/helpers/unreachable.ts
+++ b/src/helpers/unreachable.ts
@@ -2,3 +2,7 @@ export function unreachable(value: never): never {
   console.error('unreachable branch reached with value', value);
   throw new Error('unreachable branch reached');
 }
+
+export function defaultForNever<T>(value: never, defaultValue: T): T {
+  return defaultValue;
+}

--- a/src/helpers/unreachable.ts
+++ b/src/helpers/unreachable.ts
@@ -1,0 +1,4 @@
+export function unreachable(value: never): never {
+  console.error('unreachable branch reached with value', value);
+  throw new Error('unreachable branch reached');
+}

--- a/src/pages/DeepFocusPage.tsx
+++ b/src/pages/DeepFocusPage.tsx
@@ -6,12 +6,14 @@ import styled from 'styled-components';
 import { SampleTable } from '../components/SampleTable';
 import { VariantHeader } from '../components/VariantHeader';
 import { scrollableContainerPaddingPx, scrollableContainerStyle } from '../helpers/scrollable-container';
+import { SamplingStrategy } from '../services/api';
 import { Country, Variant } from '../services/api-types';
 
 interface Props {
   country: Country;
   matchPercentage: number;
   variant: Variant;
+  samplingStrategy: SamplingStrategy;
 }
 
 const OuterWrapper = styled.div`

--- a/src/pages/EmbedPage.tsx
+++ b/src/pages/EmbedPage.tsx
@@ -8,7 +8,7 @@ const host = process.env.REACT_APP_WEBSITE_HOST;
 export function EmbedPage() {
   const widgetUrlName = (useParams() as any).widget as string; // TODO(voinovp) use add types for react-router params
   const widget = allWidgets.find(w => w.urlName === widgetUrlName);
-  const widgetProps = useQueryWithEncoder(widget?.propsEncoder);
+  const widgetProps = useQueryWithEncoder<unknown>(widget?.propsEncoder);
 
   if (!widget || !widgetProps) {
     // TODO Redirect to a 404 page
@@ -25,7 +25,7 @@ export function EmbedPage() {
         .
       </div>
       <div style={{ flexGrow: 1 }}>
-        <widget.Component {...widgetProps} />
+        <widget.Component {...(widgetProps as any)} />
       </div>
     </div>
   );

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -1,62 +1,35 @@
-import React, { useMemo } from 'react';
-import { generatePath, Route, Switch, useHistory, useParams, useRouteMatch } from 'react-router';
+import React from 'react';
+import { Route, Switch, useHistory, useRouteMatch } from 'react-router';
 import { ExploreWrapper, FocusWrapper, RawFullContentWrapper } from '../helpers/app-layout';
-import { ZodQueryEncoder } from '../helpers/query-encoder';
-import { VariantSelector, VariantSelectorSchema } from '../helpers/sample-selector';
+import { getFocusPageLink, useExploreUrl } from '../helpers/explore-url';
 import { DeepFocusPage } from '../pages/DeepFocusPage';
 import { ExplorePage } from '../pages/ExplorePage';
 import { FocusEmptyPage } from '../pages/FocusEmptyPage';
 import { FocusPage } from '../pages/FocusPage';
-import { SamplingStrategy } from '../services/api';
-import { Country } from '../services/api-types';
 
-const queryEncoder = new ZodQueryEncoder(VariantSelectorSchema);
-
-export function getFocusPageLink(
-  variantSelector: VariantSelector,
-  country: Country,
-  deepFocusPath: string = ''
-) {
-  return (
-    generatePath(`/explore/${country}/variants/:variantSelector`, {
-      variantSelector: queryEncoder.encode(variantSelector).toString(),
-    }) + deepFocusPath
-  );
-}
-
-interface Props {
-  samplingStrategy: SamplingStrategy;
-}
-
-export const ExploreFocusSplit = ({ samplingStrategy }: Props) => {
-  const { country } = useParams<{ country: string }>();
+export const ExploreFocusSplit = () => {
+  const { country, samplingStrategy, variantSelector, focusKey } = useExploreUrl() || {};
 
   const { path } = useRouteMatch();
-  const variantRouteMatch = useRouteMatch<{ variantSelector: string }>(`${path}/variants/:variantSelector`);
-  const encodedVariantSelector = variantRouteMatch?.params.variantSelector;
-  const variantSelector = useMemo(() => {
-    try {
-      if (encodedVariantSelector) {
-        return queryEncoder.decode(new URLSearchParams(encodedVariantSelector));
-      }
-    } catch (err) {
-      console.error('could not decode variant selector', encodedVariantSelector);
-    }
-  }, [encodedVariantSelector]);
 
   const history = useHistory();
+
+  if (!country || !samplingStrategy) {
+    // This may happen during a redirect
+    return null;
+  }
 
   const explorePage = (
     <ExploreWrapper>
       <ExplorePage
         country={country}
-        onVariantSelect={variant => history.push(getFocusPageLink(variant, country))}
+        onVariantSelect={variantSelector =>
+          history.push(getFocusPageLink({ variantSelector, country, samplingStrategy }))
+        }
         selection={variantSelector}
       />
     </ExploreWrapper>
   );
-
-  const focusKey = `${encodedVariantSelector}-${samplingStrategy}`;
 
   return (
     <>

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -7,6 +7,7 @@ import { DeepFocusPage } from '../pages/DeepFocusPage';
 import { ExplorePage } from '../pages/ExplorePage';
 import { FocusEmptyPage } from '../pages/FocusEmptyPage';
 import { FocusPage } from '../pages/FocusPage';
+import { SamplingStrategy } from '../services/api';
 import { Country } from '../services/api-types';
 
 const queryEncoder = new ZodQueryEncoder(VariantSelectorSchema);
@@ -23,7 +24,11 @@ export function getFocusPageLink(
   );
 }
 
-export const ExploreFocusSplit = () => {
+interface Props {
+  samplingStrategy: SamplingStrategy;
+}
+
+export const ExploreFocusSplit = ({ samplingStrategy }: Props) => {
   const { country } = useParams<{ country: string }>();
 
   const { path } = useRouteMatch();
@@ -51,7 +56,7 @@ export const ExploreFocusSplit = () => {
     </ExploreWrapper>
   );
 
-  const focusKey = encodedVariantSelector;
+  const focusKey = `${encodedVariantSelector}-${samplingStrategy}`;
 
   return (
     <>
@@ -65,12 +70,26 @@ export const ExploreFocusSplit = () => {
         <Route exact path={`${path}/variants/:variantSelector`}>
           {explorePage}
           <FocusWrapper>
-            {variantSelector && <FocusPage key={focusKey} {...variantSelector} country={country} />}
+            {variantSelector && (
+              <FocusPage
+                {...variantSelector}
+                key={focusKey}
+                country={country}
+                samplingStrategy={samplingStrategy}
+              />
+            )}
           </FocusWrapper>
         </Route>
         <Route path={`${path}/variants/:variantSelector`}>
           <RawFullContentWrapper>
-            {variantSelector && <DeepFocusPage key={focusKey} {...variantSelector} country={country} />}
+            {variantSelector && (
+              <DeepFocusPage
+                {...variantSelector}
+                key={focusKey}
+                country={country}
+                samplingStrategy={samplingStrategy}
+              />
+            )}
           </RawFullContentWrapper>
         </Route>
       </Switch>

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -1,25 +1,28 @@
 import React from 'react';
+import { FocusVariantHeaderControls } from '../components/FocusVariantHeaderControls';
 import { InternationalComparison } from '../components/InternationalComparison';
-import { Country, Variant } from '../services/api-types';
-import { VariantHeader } from '../components/VariantHeader';
-import { VariantAgeDistributionPlotWidget } from '../widgets/VariantAgeDistributionPlot';
-import { VariantTimeDistributionPlotWidget } from '../widgets/VariantTimeDistributionPlot';
 import { NamedSection } from '../components/NamedSection';
 import Switzerland from '../components/Switzerland';
-import { FocusVariantHeaderControls } from '../components/FocusVariantHeaderControls';
+import { VariantHeader } from '../components/VariantHeader';
+import { SamplingStrategy, toLiteralSamplingStrategy } from '../services/api';
+import { Country, Variant } from '../services/api-types';
+import { VariantAgeDistributionPlotWidget } from '../widgets/VariantAgeDistributionPlot';
+import { VariantTimeDistributionPlotWidget } from '../widgets/VariantTimeDistributionPlot';
 
 interface Props {
   country: Country;
   matchPercentage: number;
   variant: Variant;
+  samplingStrategy: SamplingStrategy;
 }
 
 export const FocusPage = (props: Props) => {
-  const { country, matchPercentage, variant } = props;
+  const { country, matchPercentage, variant, samplingStrategy } = props;
   const plotProps = {
     country,
     matchPercentage,
     mutations: variant.mutations,
+    samplingStrategy: toLiteralSamplingStrategy(samplingStrategy),
   };
   return (
     <>

--- a/src/pages/GlobalSamplePage.tsx
+++ b/src/pages/GlobalSamplePage.tsx
@@ -4,6 +4,7 @@ import { VariantHeader } from '../components/VariantHeader';
 import { ZodQueryEncoder } from '../helpers/query-encoder';
 import { VariantSelector, VariantSelectorSchema } from '../helpers/sample-selector';
 import { useQueryWithEncoder } from '../helpers/use-query';
+import { SamplingStrategy } from '../services/api';
 
 export const queryEncoder = new ZodQueryEncoder(VariantSelectorSchema);
 
@@ -23,7 +24,11 @@ export const GlobalSamplePage = () => {
   return (
     <>
       <VariantHeader variant={variant} titleSuffix='Worldwide samples' />
-      <SampleTable variant={variant} matchPercentage={matchPercentage} />
+      <SampleTable
+        variant={variant}
+        matchPercentage={matchPercentage}
+        samplingStrategy={SamplingStrategy.AllSamples}
+      />
     </>
   );
 };

--- a/src/services/NextcladeService.ts
+++ b/src/services/NextcladeService.ts
@@ -1,15 +1,21 @@
 import { Variant } from './api-types';
 import { AccountService } from './AccountService';
-import { getSampleFastaUrl } from './api';
+import { getSampleFastaUrl, LiteralSamplingStrategy } from './api';
 
 export class NextcladeService {
-  static async showVariantOnNextclade(
-    variant: Variant,
-    matchPercentage: number,
-    country: string | undefined | null
-  ) {
+  static async showVariantOnNextclade({
+    variant,
+    matchPercentage,
+    country,
+    samplingStrategy,
+  }: {
+    variant: Variant;
+    matchPercentage: number;
+    country: string | undefined | null;
+    samplingStrategy: LiteralSamplingStrategy;
+  }) {
     const mutationsString = variant.mutations.join(',');
-    let endpoint = getSampleFastaUrl({ mutationsString, matchPercentage, country });
+    let endpoint = getSampleFastaUrl({ mutationsString, matchPercentage, country, samplingStrategy });
     if (AccountService.isLoggedIn()) {
       const jwt = await AccountService.createTemporaryJwt('/resource/sample-fasta');
       endpoint += '&jwt=' + jwt;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,5 @@
 import * as zod from 'zod';
+import { unreachable } from '../helpers/unreachable';
 import { AccountService } from './AccountService';
 import {
   AgeDistributionEntrySchema,
@@ -23,6 +24,20 @@ export enum DistributionType {
 export enum SamplingStrategy {
   AllSamples = 'AllSamples',
   Surveillance = 'Surveillance',
+}
+
+export const LiteralSamplingStrategySchema = zod.literal('SURVEILLANCE').nullable();
+export type LiteralSamplingStrategy = zod.infer<typeof LiteralSamplingStrategySchema>;
+
+export function toLiteralSamplingStrategy(samplingStrategy: SamplingStrategy): LiteralSamplingStrategy {
+  switch (samplingStrategy) {
+    case SamplingStrategy.AllSamples:
+      return null;
+    case SamplingStrategy.Surveillance:
+      return 'SURVEILLANCE';
+    default:
+      unreachable(samplingStrategy);
+  }
 }
 
 const HOST = process.env.REACT_APP_SERVER_HOST;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 import * as zod from 'zod';
-import { unreachable } from '../helpers/unreachable';
+import { defaultForNever, unreachable } from '../helpers/unreachable';
 import { AccountService } from './AccountService';
 import {
   AgeDistributionEntrySchema,
@@ -21,6 +21,7 @@ export enum DistributionType {
   TimeZipCode = 'TimeZipCode',
 }
 
+// WARNING These values are used in URLs - be careful when changing them
 export enum SamplingStrategy {
   AllSamples = 'AllSamples',
   Surveillance = 'Surveillance',
@@ -37,6 +38,17 @@ export function toLiteralSamplingStrategy(samplingStrategy: SamplingStrategy): L
       return 'SURVEILLANCE';
     default:
       unreachable(samplingStrategy);
+  }
+}
+
+export function isSamplingStrategy(s: string): s is SamplingStrategy {
+  const _s = s as SamplingStrategy;
+  switch (_s) {
+    case SamplingStrategy.AllSamples:
+    case SamplingStrategy.Surveillance:
+      return true;
+    default:
+      return defaultForNever(_s, false);
   }
 }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -160,16 +160,21 @@ export const getSamples = (
     mutationsString,
     matchPercentage,
     country,
+    samplingStrategy,
   }: {
     mutationsString: string;
     matchPercentage: number;
     country: string | null | undefined;
+    samplingStrategy: LiteralSamplingStrategy;
   },
   signal?: AbortSignal
 ): Promise<SampleResultList> => {
   let url = HOST + `/resource/sample/?mutations=${mutationsString}&matchPercentage=${matchPercentage}`;
   if (country) {
     url += `&country=${country}`;
+  }
+  if (samplingStrategy) {
+    url += `&dataType=${samplingStrategy}`;
   }
   return fetch(url, { headers: getBaseHeaders(), signal })
     .then(response => response.json())

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -164,14 +164,19 @@ export const getSampleFastaUrl = ({
   mutationsString,
   matchPercentage,
   country,
+  samplingStrategy,
 }: {
   mutationsString: string;
   matchPercentage: number;
   country: string | null | undefined;
+  samplingStrategy: LiteralSamplingStrategy;
 }): string => {
   let url = HOST + `/resource/sample-fasta?mutations=${mutationsString}&matchPercentage=${matchPercentage}`;
   if (country) {
     url += `&country=${country}`;
+  }
+  if (samplingStrategy) {
+    url += `&dataType=${samplingStrategy}`;
   }
   return url;
 };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -27,13 +27,13 @@ export enum SamplingStrategy {
   Surveillance = 'Surveillance',
 }
 
-export const LiteralSamplingStrategySchema = zod.literal('SURVEILLANCE').nullable();
+export const LiteralSamplingStrategySchema = zod.literal('SURVEILLANCE').optional();
 export type LiteralSamplingStrategy = zod.infer<typeof LiteralSamplingStrategySchema>;
 
 export function toLiteralSamplingStrategy(samplingStrategy: SamplingStrategy): LiteralSamplingStrategy {
   switch (samplingStrategy) {
     case SamplingStrategy.AllSamples:
-      return null;
+      return undefined;
     case SamplingStrategy.Surveillance:
       return 'SURVEILLANCE';
     default:

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,6 +20,11 @@ export enum DistributionType {
   TimeZipCode = 'TimeZipCode',
 }
 
+export enum SamplingStrategy {
+  AllSamples = 'AllSamples',
+  Surveillance = 'Surveillance',
+}
+
 const HOST = process.env.REACT_APP_SERVER_HOST;
 
 const getBaseHeaders = (): Headers => {

--- a/src/widgets/VariantAgeDistributionPlot.tsx
+++ b/src/widgets/VariantAgeDistributionPlot.tsx
@@ -12,7 +12,7 @@ import { EntryWithoutCI, removeCIFromEntry } from '../helpers/confidence-interva
 const PropsSchema = SampleSelectorSchema;
 type Props = zod.infer<typeof PropsSchema>;
 
-const VariantAgeDistributionPlot = ({ country, mutations, matchPercentage }: Props) => {
+const VariantAgeDistributionPlot = ({ country, mutations, matchPercentage, samplingStrategy }: Props) => {
   const [distributionData, setDistributionData] = useState<EntryWithoutCI<AgeDistributionEntry>[]>();
 
   useEffect(() => {
@@ -25,6 +25,7 @@ const VariantAgeDistributionPlot = ({ country, mutations, matchPercentage }: Pro
         country,
         mutations,
         matchPercentage,
+        samplingStrategy,
       },
       signal
     )
@@ -42,7 +43,7 @@ const VariantAgeDistributionPlot = ({ country, mutations, matchPercentage }: Pro
       isSubscribed = false;
       controller.abort();
     };
-  }, [country, mutations, matchPercentage]);
+  }, [country, mutations, matchPercentage, samplingStrategy]);
 
   return (
     <div style={{ height: '100%' }}>

--- a/src/widgets/VariantInternationalComparisonPlot.tsx
+++ b/src/widgets/VariantInternationalComparisonPlot.tsx
@@ -4,7 +4,12 @@ import { Plot } from '../components/Plot';
 import { EntryWithoutCI, removeCIFromEntry } from '../helpers/confidence-interval';
 import { fillGroupedWeeklyApiData } from '../helpers/fill-missing';
 import { ZodQueryEncoder } from '../helpers/query-encoder';
-import { DistributionType, getVariantDistributionData } from '../services/api';
+import {
+  DistributionType,
+  getVariantDistributionData,
+  SamplingStrategy,
+  toLiteralSamplingStrategy,
+} from '../services/api';
 import { CountrySchema, InternationalTimeDistributionEntry } from '../services/api-types';
 import { Widget } from './Widget';
 
@@ -34,6 +39,7 @@ const VariantInternationalComparisonPlot = ({ country, mutations, matchPercentag
         country,
         mutations,
         matchPercentage,
+        samplingStrategy: toLiteralSamplingStrategy(SamplingStrategy.AllSamples),
       },
       signal
     ).then(newDistributionData => {

--- a/src/widgets/VariantInternationalComparisonPlot.tsx
+++ b/src/widgets/VariantInternationalComparisonPlot.tsx
@@ -4,18 +4,18 @@ import { Plot } from '../components/Plot';
 import { EntryWithoutCI, removeCIFromEntry } from '../helpers/confidence-interval';
 import { fillGroupedWeeklyApiData } from '../helpers/fill-missing';
 import { ZodQueryEncoder } from '../helpers/query-encoder';
-import { SampleSelectorSchema } from '../helpers/sample-selector';
 import { DistributionType, getVariantDistributionData } from '../services/api';
-import { InternationalTimeDistributionEntry } from '../services/api-types';
+import { CountrySchema, InternationalTimeDistributionEntry } from '../services/api-types';
 import { Widget } from './Widget';
 
 const digitsForPercent = (v: number): string => (v * 100).toFixed(2);
 
-const PropsSchema = SampleSelectorSchema.merge(
-  zod.object({
-    logScale: zod.boolean().optional(),
-  })
-);
+const PropsSchema = zod.object({
+  country: CountrySchema,
+  matchPercentage: zod.number(),
+  mutations: zod.array(zod.string()),
+  logScale: zod.boolean().optional(),
+});
 type Props = zod.infer<typeof PropsSchema>;
 
 const VariantInternationalComparisonPlot = ({ country, mutations, matchPercentage, logScale }: Props) => {

--- a/src/widgets/VariantTimeDistributionPlot.tsx
+++ b/src/widgets/VariantTimeDistributionPlot.tsx
@@ -25,7 +25,12 @@ export const colors = {
   secondary: '#7f8c8d',
 };
 
-export const VariantTimeDistributionPlot = ({ country, mutations, matchPercentage }: Props) => {
+export const VariantTimeDistributionPlot = ({
+  country,
+  mutations,
+  matchPercentage,
+  samplingStrategy,
+}: Props) => {
   const [distribution, setDistribution] = useState<EntryWithoutCI<TimeDistributionEntry>[] | undefined>(
     undefined
   );
@@ -40,6 +45,7 @@ export const VariantTimeDistributionPlot = ({ country, mutations, matchPercentag
         country,
         mutations,
         matchPercentage,
+        samplingStrategy,
       },
       signal
     ).then(newDistributionData => {
@@ -53,7 +59,7 @@ export const VariantTimeDistributionPlot = ({ country, mutations, matchPercentag
       isSubscribed = false;
       controller.abort();
     };
-  }, [country, mutations, matchPercentage]);
+  }, [country, mutations, matchPercentage, samplingStrategy]);
 
   const processedData: TimeEntry[] | undefined = distribution?.map(d => ({
     firstDayInWeek: d.x.firstDayInWeek,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "strictNullChecks": true,
+    "downlevelIteration": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",


### PR DESCRIPTION
This closes #31. It adds a "Sampling strategy" dropdown in the header next to the country select. It is hidden on all of the screens where it is not applicable. It is shown but disabled when the country is not Switzerland.

In general the setting is not saved in the URL or in local storage. We could put it in local storage in the future, but putting it in the URL will be hard. Note that the setting is saved in the URL of embeded plots.

Since the international comparison endpoints don't support only showing surveillance samples, but that component is still in the focus panel, I added a warning message if the sampling strategy is not set to "All samples".

@chaoran-chen I'm not sure if the server is handling the filter correctly for `/plot/variant/time-zip-code-distribution`. I checked that the query parameter is added in the request, but I can't see a visual change on the map.