### PR TITLE
Improve structure of focus pages

### DIFF
--- a/src/components/FocusVariantHeaderControls.tsx
+++ b/src/components/FocusVariantHeaderControls.tsx
@@ -29,7 +29,7 @@ export const FocusVariantHeaderControls = ({
           samplingStrategy: toLiteralSamplingStrategy(samplingStrategy),
         })
       }
-      variant='outline-dark'
+      variant='secondary'
       size='sm'
       className='mr-2'
     >
@@ -56,7 +56,7 @@ export const FocusVariantHeaderControls = ({
       )}
       <LazySampleButton
         query={{ variantSelector: { variant, matchPercentage }, country, samplingStrategy }}
-        variant='outline-dark'
+        variant='secondary'
         size='sm'
       >
         Show samples

--- a/src/components/InternationalComparison.tsx
+++ b/src/components/InternationalComparison.tsx
@@ -13,6 +13,7 @@ import { NextcladeService } from '../services/NextcladeService';
 import { Utils } from '../services/Utils';
 import { VariantInternationalComparisonPlotWidget } from '../widgets/VariantInternationalComparisonPlot';
 import { LazySampleButton } from './LazySampleButton';
+import { MinimalWidgetLayout } from './MinimalWidgetLayout';
 
 interface Props {
   country: Country;
@@ -105,7 +106,8 @@ export const InternationalComparison = ({
 
       <VariantInternationalComparisonPlotWidget.ShareableComponent
         title='International comparison'
-        height={500}
+        widgetLayout={MinimalWidgetLayout}
+        height={300}
         country={country}
         matchPercentage={matchPercentage}
         mutations={variant.mutations}
@@ -148,63 +150,59 @@ export const InternationalComparison = ({
         }
       />
 
-      {countryData ? (
-        <>
-          <div style={{ maxHeight: '400px', overflow: 'auto' }}>
-            <Table striped bordered hover>
-              <thead>
-                <tr>
-                  <th>Country</th>
-                  <th>Total Variant Sequences</th>
-                  <th>First seq. found at</th>
-                  <th>Last seq. found at</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {countryData.map((c: any) => (
-                  <tr key={c.country}>
-                    <td>{c.country}</td>
-                    <td>{c.count}</td>
-                    <td>{c.first.yearWeek}</td>
-                    <td>{c.last.yearWeek}</td>
-                    <td>
-                      {AccountService.isLoggedIn() && (
-                        <Button
-                          onClick={() =>
-                            NextcladeService.showVariantOnNextclade({
-                              variant,
-                              matchPercentage,
-                              country: c.country,
-                              samplingStrategy: toLiteralSamplingStrategy(SamplingStrategy.AllSamples),
-                            })
-                          }
-                          variant='secondary'
-                          size='sm'
-                          className='mr-2'
-                        >
-                          Show on Nextclade
-                        </Button>
-                      )}
-                      <LazySampleButton
-                        query={{
-                          variantSelector: { variant, matchPercentage },
+      {countryData && (
+        <Table striped bordered hover>
+          <thead>
+            <tr>
+              <th>Country</th>
+              <th>Total Variant Sequences</th>
+              <th>First seq. found at</th>
+              <th>Last seq. found at</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {countryData.map((c: any) => (
+              <tr key={c.country}>
+                <td>{c.country}</td>
+                <td>{c.count}</td>
+                <td>{c.first.yearWeek}</td>
+                <td>{c.last.yearWeek}</td>
+                <td>
+                  {AccountService.isLoggedIn() && (
+                    <Button
+                      onClick={() =>
+                        NextcladeService.showVariantOnNextclade({
+                          variant,
+                          matchPercentage,
                           country: c.country,
-                          samplingStrategy: SamplingStrategy.AllSamples,
-                        }}
-                        variant='secondary'
-                        size='sm'
-                      >
-                        Show samples
-                      </LazySampleButton>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          </div>
-        </>
-      ) : null}
+                          samplingStrategy: toLiteralSamplingStrategy(SamplingStrategy.AllSamples),
+                        })
+                      }
+                      variant='secondary'
+                      size='sm'
+                      className='mr-2'
+                    >
+                      Show on Nextclade
+                    </Button>
+                  )}
+                  <LazySampleButton
+                    query={{
+                      variantSelector: { variant, matchPercentage },
+                      country: c.country,
+                      samplingStrategy: SamplingStrategy.AllSamples,
+                    }}
+                    variant='secondary'
+                    size='sm'
+                  >
+                    Show samples
+                  </LazySampleButton>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
     </>
   );
 };

--- a/src/components/InternationalComparison.tsx
+++ b/src/components/InternationalComparison.tsx
@@ -111,12 +111,12 @@ export const InternationalComparison = ({
         logScale={logScale}
         toolbarChildren={
           <>
-            <Button variant='outline-primary' size='sm' className='ml-1' onClick={() => setLogScale(v => !v)}>
+            <Button variant='secondary' size='sm' className='ml-1' onClick={() => setLogScale(v => !v)}>
               Toggle log scale
             </Button>
             {AccountService.isLoggedIn() && (
               <Button
-                variant='outline-primary'
+                variant='secondary'
                 size='sm'
                 className='ml-1'
                 onClick={() =>
@@ -137,7 +137,7 @@ export const InternationalComparison = ({
                 country: undefined,
                 samplingStrategy: SamplingStrategy.AllSamples,
               }}
-              variant='outline-primary'
+              variant='secondary'
               size='sm'
               className='ml-1'
             >
@@ -178,7 +178,7 @@ export const InternationalComparison = ({
                               samplingStrategy: toLiteralSamplingStrategy(SamplingStrategy.AllSamples),
                             })
                           }
-                          variant='outline-dark'
+                          variant='secondary'
                           size='sm'
                           className='mr-2'
                         >
@@ -191,7 +191,7 @@ export const InternationalComparison = ({
                           country: c.country,
                           samplingStrategy: SamplingStrategy.AllSamples,
                         }}
-                        variant='outline-dark'
+                        variant='secondary'
                         size='sm'
                       >
                         Show samples

--- a/src/components/InternationalComparison.tsx
+++ b/src/components/InternationalComparison.tsx
@@ -104,6 +104,7 @@ export const InternationalComparison = ({
       )}
 
       <VariantInternationalComparisonPlotWidget.ShareableComponent
+        title='International comparison'
         height={500}
         country={country}
         matchPercentage={matchPercentage}

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -7,6 +7,7 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   padding: 5rem;
+  height: 100%;
 `;
 
 const Loader = () => {

--- a/src/components/MinimalWidgetLayout.tsx
+++ b/src/components/MinimalWidgetLayout.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface Props {
+  title: string;
+  toolbar?: React.ReactChild | React.ReactChild[];
+  children: React.ReactChild | React.ReactChild[];
+}
+
+export const MinimalWidgetLayout = ({ title, toolbar, children }: Props) => {
+  return (
+    <div>
+      {toolbar}
+      {children}
+    </div>
+  );
+};

--- a/src/components/NamedCard.tsx
+++ b/src/components/NamedCard.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface Props {
+  title: string;
+  toolbar?: React.ReactChild | React.ReactChild[];
+  children: React.ReactChild | React.ReactChild[];
+}
+
+const Card = styled.div`
+  position: relative;
+  margin: 5px;
+  background: white;
+  padding: 12px 15px;
+  border: 1px solid #0000001f;
+  box-shadow: #00000059 0 2px 3px 0px;
+  height: 100%;
+`;
+
+const Title = styled.h3`
+  font-size: 1.5rem;
+  margin-bottom: 15px;
+`;
+
+const ToolbarWrapper = styled.div`
+  position: absolute;
+  top: 12px;
+  right: 12px;
+`;
+
+const ContentWrapper = styled.div`
+  margin-bottom: 30px;
+`;
+
+export const NamedCard = ({ title, toolbar, children }: Props) => {
+  return (
+    <Card>
+      <Title>{title}</Title>
+      <ToolbarWrapper>{toolbar}</ToolbarWrapper>
+      <ContentWrapper>{children}</ContentWrapper>
+    </Card>
+  );
+};

--- a/src/components/NamedCard.tsx
+++ b/src/components/NamedCard.tsx
@@ -14,7 +14,6 @@ const Card = styled.div`
   padding: 12px 15px;
   border: 1px solid #0000001f;
   box-shadow: #00000059 0 2px 3px 0px;
-  height: 100%;
 `;
 
 const Title = styled.h3`

--- a/src/components/NamedSection.tsx
+++ b/src/components/NamedSection.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 interface Props {
   title: string;
-  children: React.ReactChild | React.ReactChild[];
+  children: React.ReactNode;
 }
 
 const ContentWrapper = styled.div`

--- a/src/components/NewVariantTable.tsx
+++ b/src/components/NewVariantTable.tsx
@@ -54,7 +54,7 @@ export const NewVariantTable = ({ country, onVariantSelect }: Props) => {
                       onClick={() => {
                         onVariantSelect(d.variant);
                       }}
-                      variant='outline-secondary'
+                      variant='secondary'
                       size='sm'
                     >
                       Show Details

--- a/src/components/PackedGrid/PackedGrid.tsx
+++ b/src/components/PackedGrid/PackedGrid.tsx
@@ -7,6 +7,7 @@ import { GridCell, Props as GridCellProps } from './GridCell';
 
 interface Props {
   children: React.ReactNode;
+  maxColumns?: number;
 }
 
 function childIsGridCell(
@@ -20,7 +21,7 @@ const Row = styled.div`
   align-items: stretch;
 `;
 
-export const PackedGrid = ({ children }: Props) => {
+export const PackedGrid = ({ children, maxColumns }: Props) => {
   const childrenAsArray: (React.ReactChild | {})[] = React.Children.toArray(children);
   const gridCellChildren = childrenAsArray
     .map(c => (childIsGridCell(c) ? c : undefined))
@@ -39,7 +40,7 @@ export const PackedGrid = ({ children }: Props) => {
   let placedGridCells: PlacedGridCell[][] = [];
   if (width) {
     try {
-      placedGridCells = placeGridCells(requests, Math.floor(width));
+      placedGridCells = placeGridCells(requests, { maxColumns, parentWidth: Math.floor(width) });
     } catch (err) {
       console.error('placeGridCells failed', err);
       placedGridCells = requests.map((v, i) => [{ index: i, width }]);

--- a/src/components/PackedGrid/__tests__/algorithm.test.ts
+++ b/src/components/PackedGrid/__tests__/algorithm.test.ts
@@ -5,6 +5,7 @@ describe('placeGridCells', () => {
     label: string;
     requests: GridCellRequest[];
     parentWidth: number;
+    maxColumns?: number;
     result: PlacedGridCell[][];
   }
   const cases: Case[] = [
@@ -85,6 +86,12 @@ describe('placeGridCells', () => {
         { minWidth: 300, maxWidth: 300 },
         { minWidth: 300, maxWidth: 300 },
       ],
+      parentWidth: 300,
+      result: [[{ index: 0, width: 300 }], [{ index: 1, width: 300 }], [{ index: 2, width: 300 }]],
+    },
+    {
+      label: 'multiple grid cells (no widths means full rows)',
+      requests: [{}, {}, {}],
       parentWidth: 300,
       result: [[{ index: 0, width: 300 }], [{ index: 1, width: 300 }], [{ index: 2, width: 300 }]],
     },
@@ -187,12 +194,90 @@ describe('placeGridCells', () => {
         [{ index: 6, width: 110 }],
       ],
     },
+    {
+      label:
+        'multiple grid cells forced onto separate rows by column limit (width limited elements would fill exactly one row)',
+      requests: [
+        { minWidth: 100, maxWidth: 100 },
+        { minWidth: 150, maxWidth: 150 },
+        { minWidth: 100, maxWidth: 100 },
+      ],
+      parentWidth: 350,
+      maxColumns: 2,
+      result: [
+        [
+          { index: 0, width: 100 },
+          { index: 1, width: 150 },
+        ],
+        [{ index: 2, width: 100 }],
+      ],
+    },
+    {
+      label: 'multiple grid cells forced onto separate rows (more than one full row)',
+      requests: [
+        { minWidth: 100, maxWidth: 100 },
+        { minWidth: 150, maxWidth: 150 },
+        { minWidth: 100, maxWidth: 100 },
+        { minWidth: 150, maxWidth: 150 },
+        { minWidth: 100, maxWidth: 100 },
+        { minWidth: 100, maxWidth: 100 },
+      ],
+      parentWidth: 350,
+      maxColumns: 2,
+      result: [
+        [
+          { index: 0, width: 100 },
+          { index: 1, width: 150 },
+        ],
+        [
+          { index: 2, width: 100 },
+          { index: 3, width: 150 },
+        ],
+        [
+          { index: 4, width: 100 },
+          { index: 5, width: 100 },
+        ],
+      ],
+    },
+    {
+      label: 'multiple grid cells forced onto separate rows by column limit (no max widths)',
+      requests: [{ minWidth: 10 }, { minWidth: 10 }, { minWidth: 100 }, { minWidth: 100 }],
+      parentWidth: 300,
+      maxColumns: 2,
+      result: [
+        [
+          { index: 0, width: 150 },
+          { index: 1, width: 150 },
+        ],
+        [
+          { index: 2, width: 150 },
+          { index: 3, width: 150 },
+        ],
+      ],
+    },
+    {
+      label: 'multiple grid cells forced onto separate rows by column limit (different maxColumns value)',
+      requests: [{ minWidth: 10 }, { minWidth: 10 }, { minWidth: 100 }, { minWidth: 100 }],
+      parentWidth: 300,
+      maxColumns: 3,
+      result: [
+        [
+          { index: 0, width: 25 },
+          { index: 1, width: 25 },
+          { index: 2, width: 250 },
+        ],
+        [{ index: 3, width: 300 }],
+      ],
+    },
   ];
 
   for (const c of cases) {
     // eslint-disable-next-line jest/valid-title
     test(c.label, () => {
-      const actualResult = placeGridCells(c.requests, c.parentWidth);
+      const actualResult = placeGridCells(c.requests, {
+        parentWidth: c.parentWidth,
+        maxColumns: c.maxColumns,
+      });
       expect(actualResult).toEqual(c.result);
     });
   }

--- a/src/components/PackedGrid/algorithm.ts
+++ b/src/components/PackedGrid/algorithm.ts
@@ -12,8 +12,12 @@ export interface PlacedGridCell {
   width: number;
 }
 
-export function placeGridCells(_requests: GridCellRequest[], parentWidth: number): PlacedGridCell[][] {
+export function placeGridCells(
+  _requests: GridCellRequest[],
+  { parentWidth, maxColumns }: { parentWidth: number; maxColumns?: number }
+): PlacedGridCell[][] {
   assert(Number.isSafeInteger(parentWidth) && parentWidth >= 0);
+  assert(maxColumns === undefined || (Number.isSafeInteger(maxColumns) && maxColumns > 0));
   assert(
     _requests.every(
       request =>
@@ -39,7 +43,10 @@ export function placeGridCells(_requests: GridCellRequest[], parentWidth: number
   const rows: StrictGridCellRequest[][] = [];
   let currentRow = { items: [] as StrictGridCellRequest[], width: 0 };
   for (const request of requests) {
-    if (currentRow.items.length && currentRow.width + request.minWidth > parentWidth) {
+    if (
+      (currentRow.items.length && currentRow.width + request.minWidth > parentWidth) ||
+      (maxColumns && currentRow.items.length >= maxColumns)
+    ) {
       rows.push(currentRow.items);
       currentRow = { items: [], width: 0 };
     }

--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -1,5 +1,6 @@
 import { Button, Modal, Form, ButtonToolbar } from 'react-bootstrap';
 import { useState } from 'react';
+import { NamedCard } from '../components/NamedCard';
 
 const host = process.env.REACT_APP_WEBSITE_HOST;
 
@@ -11,10 +12,11 @@ export interface InternalProps {
 
 // ExternalProps are passed by users of Widget.ShareableComponent
 export interface ExternalProps {
+  title: string;
   toolbarChildren?: React.ReactChild | React.ReactChild[];
   height: number;
 }
-const externalPropsKeys: (keyof ExternalProps)[] = ['toolbarChildren', 'height'];
+const externalPropsKeys: (keyof ExternalProps)[] = ['title', 'toolbarChildren', 'height'];
 
 export function pickExternalProps<T extends { [K in keyof ExternalProps]?: never }>(
   allProps: T
@@ -33,7 +35,7 @@ export function pickExternalProps<T extends { [K in keyof ExternalProps]?: never
 
 type Props = InternalProps & ExternalProps;
 
-export function WidgetWrapper({ getShareUrl, children, toolbarChildren, height }: Props) {
+export function WidgetWrapper({ getShareUrl, children, title, toolbarChildren, height }: Props) {
   const [shownEmbeddingCode, setShownEmbeddingCode] = useState<string>();
 
   const onShareClick = () => {
@@ -43,15 +45,19 @@ export function WidgetWrapper({ getShareUrl, children, toolbarChildren, height }
 
   return (
     <>
-      <div style={{ position: 'relative' }}>
-        <ButtonToolbar className='mb-1'>
-          <Button variant='secondary' size='sm' onClick={onShareClick}>
-            Share
-          </Button>
-          {toolbarChildren}
-        </ButtonToolbar>
+      <NamedCard
+        title={title}
+        toolbar={
+          <ButtonToolbar className='mb-1'>
+            <Button variant='secondary' size='sm' onClick={onShareClick}>
+              Share
+            </Button>
+            {toolbarChildren}
+          </ButtonToolbar>
+        }
+      >
         <div style={{ height }}>{children}</div>
-      </div>
+      </NamedCard>
 
       <Modal size='lg' show={!!shownEmbeddingCode} onHide={() => setShownEmbeddingCode(undefined)}>
         <Modal.Header closeButton>

--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -45,7 +45,7 @@ export function WidgetWrapper({ getShareUrl, children, toolbarChildren, height }
     <>
       <div style={{ position: 'relative' }}>
         <ButtonToolbar className='mb-1'>
-          <Button variant='outline-primary' size='sm' onClick={onShareClick}>
+          <Button variant='secondary' size='sm' onClick={onShareClick}>
             Share
           </Button>
           {toolbarChildren}

--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -10,13 +10,22 @@ export interface InternalProps {
   children: React.ReactChild | React.ReactChild[];
 }
 
+// LayoutProps as passed by WidgetWrapper to the component responsible for Layout
+export interface LayoutProps {
+  title: string;
+  toolbar?: React.ReactChild | React.ReactChild[];
+  children: React.ReactChild | React.ReactChild[];
+}
+
 // ExternalProps are passed by users of Widget.ShareableComponent
 export interface ExternalProps {
   title: string;
   toolbarChildren?: React.ReactChild | React.ReactChild[];
-  height: number;
+  height?: number;
+  widgetLayout?: React.ComponentType<LayoutProps>;
 }
-const externalPropsKeys: (keyof ExternalProps)[] = ['title', 'toolbarChildren', 'height'];
+// IMPORTANT externalPropsKeys must be kept in sync with ExternalProps
+const externalPropsKeys: (keyof ExternalProps)[] = ['title', 'toolbarChildren', 'height', 'widgetLayout'];
 
 export function pickExternalProps<T extends { [K in keyof ExternalProps]?: never }>(
   allProps: T
@@ -35,7 +44,14 @@ export function pickExternalProps<T extends { [K in keyof ExternalProps]?: never
 
 type Props = InternalProps & ExternalProps;
 
-export function WidgetWrapper({ getShareUrl, children, title, toolbarChildren, height }: Props) {
+export function WidgetWrapper({
+  getShareUrl,
+  children,
+  title,
+  toolbarChildren,
+  height,
+  widgetLayout: WidgetLayout = NamedCard,
+}: Props) {
   const [shownEmbeddingCode, setShownEmbeddingCode] = useState<string>();
 
   const onShareClick = () => {
@@ -45,7 +61,7 @@ export function WidgetWrapper({ getShareUrl, children, title, toolbarChildren, h
 
   return (
     <>
-      <NamedCard
+      <WidgetLayout
         title={title}
         toolbar={
           <ButtonToolbar className='mb-1'>
@@ -56,8 +72,8 @@ export function WidgetWrapper({ getShareUrl, children, title, toolbarChildren, h
           </ButtonToolbar>
         }
       >
-        <div style={{ height }}>{children}</div>
-      </NamedCard>
+        <div style={height ? { height } : undefined}>{children}</div>
+      </WidgetLayout>
 
       <Modal size='lg' show={!!shownEmbeddingCode} onHide={() => setShownEmbeddingCode(undefined)}>
         <Modal.Header closeButton>

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -153,7 +153,7 @@ export function useExploreUrl(): ExploreUrl | undefined {
     samplingStrategy,
     setSamplingStrategy,
     variantSelector,
-    focusKey: `${country}-${samplingStrategy}-${variantSelector}`,
+    focusKey: `${country}-${samplingStrategy}-${encodedVariantSelector}`,
   };
 }
 

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -168,6 +168,7 @@ export function getFocusPageLink({
   samplingStrategy: SamplingStrategy;
   deepFocusPath?: string;
 }) {
+  assert(!deepFocusPath || deepFocusPath.startsWith('/'));
   return (
     generatePath(`/explore/${country}/${samplingStrategy}/variants/:variantSelector`, {
       variantSelector: queryEncoder.encode(variantSelector).toString(),

--- a/src/models/chen2021Fitness/Chen2021AbsolutePlot.tsx
+++ b/src/models/chen2021Fitness/Chen2021AbsolutePlot.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Plot } from '../../components/Plot';
+import { Chen2021FitnessResponse } from './chen2021Fitness-types';
+
+interface Props {
+  modelData: Chen2021FitnessResponse;
+}
+
+export const Chen2021AbsolutePlot = ({ modelData }: Props) => {
+  return (
+    <Plot
+      style={{ width: '100%', height: '100%' }}
+      data={[
+        {
+          name: 'Wildtype',
+          type: 'scatter',
+          mode: 'lines',
+          x: modelData.plotAbsoluteNumbers.t.map(dateString => new Date(dateString)),
+          y: modelData.plotAbsoluteNumbers.wildtypeCases,
+          stackgroup: 'one',
+        },
+        {
+          name: 'Variant',
+          type: 'scatter',
+          mode: 'lines',
+          x: modelData.plotAbsoluteNumbers.t.map(dateString => new Date(dateString)),
+          y: modelData.plotAbsoluteNumbers.variantCases,
+          stackgroup: 'one',
+        },
+      ]}
+      layout={{
+        title: 'Changes in absolute case numbers through time',
+        xaxis: {
+          hoverformat: '%d.%m.%Y',
+        },
+      }}
+      config={{
+        displaylogo: false,
+        modeBarButtons: [['zoom2d', 'toImage', 'resetScale2d', 'pan2d']],
+        responsive: true,
+      }}
+    />
+  );
+};

--- a/src/models/chen2021Fitness/Chen2021FitnessContainer.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessContainer.tsx
@@ -8,11 +8,6 @@ import { Chen2021FitnessResults } from './Chen2021FitnessResults';
 
 type ContainerProps = zod.infer<typeof SampleSelectorSchema>;
 
-const Wrapper = styled.div`
-  background-color: #ffe0b6;
-  padding: 15px;
-`;
-
 const SectionHeader = styled.h5`
   margin-top: 20px;
 `;
@@ -68,8 +63,7 @@ export const Chen2021FitnessContainer = ({
   };
 
   return (
-    <Wrapper>
-      <h4>Fitness Advantage Estimation</h4>
+    <>
       <p>
         The model assumes that the increase or decrease of the proportion of a variant follows a logistic
         function. It fits a logistic model to the data by optimizing the maximum likelihood to obtain the
@@ -130,6 +124,6 @@ export const Chen2021FitnessContainer = ({
           </a>
         </li>
       </ul>
-    </Wrapper>
+    </>
   );
 };

--- a/src/models/chen2021Fitness/Chen2021FitnessContainer.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessContainer.tsx
@@ -5,6 +5,7 @@ import * as zod from 'zod';
 import { SampleSelectorSchema } from '../../helpers/sample-selector';
 import styled from 'styled-components';
 import { Chen2021FitnessResults } from './Chen2021FitnessResults';
+import { fillRequestWithDefaults } from './loading';
 
 type ContainerProps = zod.infer<typeof SampleSelectorSchema>;
 
@@ -18,19 +19,9 @@ export const Chen2021FitnessContainer = ({
   matchPercentage,
   samplingStrategy,
 }: ContainerProps) => {
-  const [paramData, setParamData] = useState<Chen2021FitnessRequest>({
-    country,
-    mutations,
-    matchPercentage,
-    samplingStrategy,
-    alpha: 0.95,
-    generationTime: 4.8,
-    reproductionNumberWildtype: 1,
-    plotStartDate: new Date('2021-01-01'),
-    plotEndDate: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
-    initialWildtypeCases: 1000,
-    initialVariantCases: 100,
-  });
+  const [paramData, setParamData] = useState<Chen2021FitnessRequest>(() =>
+    fillRequestWithDefaults({ country, mutations, matchPercentage, samplingStrategy })
+  );
   const [formGenerationTime, setFormGenerationTime] = useState(paramData.generationTime.toString());
   const [formReproductionNumberWildtype, setFormReproductionNumberWildtype] = useState(
     paramData.reproductionNumberWildtype.toString()

--- a/src/models/chen2021Fitness/Chen2021FitnessPreview.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessPreview.tsx
@@ -1,0 +1,33 @@
+import React, { useMemo } from 'react';
+import * as zod from 'zod';
+import Loader from '../../components/Loader';
+import { SampleSelectorSchema } from '../../helpers/sample-selector';
+import { Chen2021ProportionPlot } from './Chen2021ProportionPlot';
+import { fillRequestWithDefaults, useModelData } from './loading';
+
+type Props = zod.infer<typeof SampleSelectorSchema>;
+
+export const Chen2021FitnessPreview = ({ country, mutations, matchPercentage, samplingStrategy }: Props) => {
+  const request = useMemo(
+    () => fillRequestWithDefaults({ country, mutations, matchPercentage, samplingStrategy }),
+    [country, mutations, matchPercentage, samplingStrategy]
+  );
+
+  const { modelData, loading } = useModelData(request);
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (!modelData) {
+    return <>A fitness advantage cannot be estimated for this variant.</>;
+  }
+
+  return (
+    <Chen2021ProportionPlot
+      modelData={modelData}
+      plotStartDate={request.plotStartDate}
+      plotEndDate={request.plotEndDate}
+    />
+  );
+};

--- a/src/models/chen2021Fitness/Chen2021FitnessResults.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessResults.tsx
@@ -1,73 +1,21 @@
-import React, { useEffect, useState } from 'react';
-import { get } from '../../services/api';
+import React from 'react';
+import Loader from '../../components/Loader';
 import { Chen2021AbsolutePlot } from './Chen2021AbsolutePlot';
-import {
-  Chen2021FitnessRequest,
-  Chen2021FitnessResponse,
-  Chen2021FitnessResponseSchema,
-} from './chen2021Fitness-types';
+import { Chen2021FitnessRequest } from './chen2021Fitness-types';
 import { Chen2021ProportionPlot } from './Chen2021ProportionPlot';
 import { formatValueWithCI } from './format-value';
+import { useModelData } from './loading';
 
 type ResultsProps = {
   request: Chen2021FitnessRequest;
 };
 
-const getData = async (
-  params: Chen2021FitnessRequest,
-  signal: AbortSignal
-): Promise<Chen2021FitnessResponse | undefined> => {
-  const mutationsString = params.mutations.join(',');
-  const urlSearchParams = new URLSearchParams({
-    country: params.country,
-    mutations: mutationsString,
-    matchPercentage: params.matchPercentage.toString(),
-    alpha: params.alpha.toString(),
-    generationTime: params.generationTime.toString(),
-    reproductionNumberWildtype: params.reproductionNumberWildtype.toString(),
-    plotStartDate: params.plotStartDate.toISOString().substring(0, 10),
-    plotEndDate: params.plotEndDate.toISOString().substring(0, 10),
-    initialWildtypeCases: params.initialWildtypeCases.toString(),
-    initialVariantCases: params.initialVariantCases.toString(),
-  });
-  if (params.samplingStrategy) {
-    urlSearchParams.set('dataType', params.samplingStrategy);
-  }
-  const url = `/computed/model/chen2021Fitness?` + urlSearchParams.toString();
-  const response = await get(url, signal);
-  if (response.status !== 200) {
-    // The computation might fail, for example, if some values go out-of-bound. The issue shall be addressed with the
-    // introduction of a better error handling and reporting on the server side.
-    return undefined;
-  }
-  const data = await response.json();
-  if (!data) {
-    return undefined;
-  }
-  return Chen2021FitnessResponseSchema.parse(data);
-};
-
 export const Chen2021FitnessResults = ({ request }: ResultsProps) => {
-  const [modelData, setModelData] = useState<Chen2021FitnessResponse | undefined | null>(undefined);
+  const { modelData, loading } = useModelData(request);
 
-  useEffect(() => {
-    let isSubscribed = true;
-    const controller = new AbortController();
-    const signal = controller.signal;
-    getData(request, signal)
-      .then(newModelData => {
-        if (isSubscribed) {
-          setModelData(newModelData);
-        }
-      })
-      .catch(e => {
-        console.log('Called fetch data error', e);
-      });
-    return () => {
-      isSubscribed = false;
-      controller.abort();
-    };
-  }, [request]);
+  if (loading) {
+    return <Loader />;
+  }
 
   if (!modelData) {
     return <>A fitness advantage cannot be estimated for this variant.</>;

--- a/src/models/chen2021Fitness/Chen2021FitnessResults.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessResults.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import * as zod from 'zod';
+import { get } from '../../services/api';
+import { Chen2021AbsolutePlot } from './Chen2021AbsolutePlot';
 import {
   Chen2021FitnessRequest,
+  Chen2021FitnessResponse,
   Chen2021FitnessResponseSchema,
-  ValueWithCISchema,
 } from './chen2021Fitness-types';
-import { Plot } from '../../components/Plot';
-import { get } from '../../services/api';
-
-type Chen2021FitnessResponse = zod.infer<typeof Chen2021FitnessResponseSchema>;
+import { Chen2021ProportionPlot } from './Chen2021ProportionPlot';
+import { formatValueWithCI } from './format-value';
 
 type ResultsProps = {
   request: Chen2021FitnessRequest;
@@ -48,23 +47,6 @@ const getData = async (
   return Chen2021FitnessResponseSchema.parse(data);
 };
 
-const formatValueWithCI = (
-  { value, ciLower, ciUpper }: zod.infer<typeof ValueWithCISchema>,
-  fractionDigits = 4,
-  usePercentSign = false
-) => {
-  if (usePercentSign) {
-    return (
-      `${(value * 100).toFixed(fractionDigits)}% ` +
-      `[${(ciLower * 100).toFixed(fractionDigits)}%, ${(ciUpper * 100).toFixed(fractionDigits)}%]`
-    );
-  } else {
-    return `${value.toFixed(fractionDigits)} [${ciLower.toFixed(fractionDigits)}, ${ciUpper.toFixed(
-      fractionDigits
-    )}]`;
-  }
-};
-
 export const Chen2021FitnessResults = ({ request }: ResultsProps) => {
   const [modelData, setModelData] = useState<Chen2021FitnessResponse | undefined | null>(undefined);
 
@@ -91,51 +73,6 @@ export const Chen2021FitnessResults = ({ request }: ResultsProps) => {
     return <>A fitness advantage cannot be estimated for this variant.</>;
   }
 
-  const filteredDaily: zod.infer<typeof Chen2021FitnessResponseSchema.shape.daily> = {
-    t: [],
-    proportion: [],
-    ciLower: [],
-    ciUpper: [],
-  };
-  const filteredDailyText = [];
-  const daily = modelData.daily;
-  for (let i = 0; i < daily.t.length; i++) {
-    const d = new Date(daily.t[i]);
-    if (d >= request.plotStartDate && d <= request.plotEndDate) {
-      filteredDaily.t.push(daily.t[i]);
-      filteredDaily.proportion.push(daily.proportion[i]);
-      filteredDaily.ciLower.push(daily.ciLower[i]);
-      filteredDaily.ciUpper.push(daily.ciUpper[i]);
-      filteredDailyText.push(
-        formatValueWithCI(
-          {
-            value: daily.proportion[i],
-            ciLower: daily.ciLower[i],
-            ciUpper: daily.ciUpper[i],
-          },
-          2,
-          true
-        )
-      );
-    }
-  }
-
-  const plotProportionText = [];
-  const plotProportion = modelData.plotProportion;
-  for (let i = 0; i < plotProportion.t.length; i++) {
-    plotProportionText.push(
-      formatValueWithCI(
-        {
-          value: plotProportion.proportion[i],
-          ciLower: plotProportion.ciLower[i],
-          ciUpper: plotProportion.ciUpper[i],
-        },
-        2,
-        true
-      )
-    );
-  }
-
   return (
     <>
       <div>Logistic growth rate a: {modelData && formatValueWithCI(modelData.params.a)}</div>
@@ -144,98 +81,16 @@ export const Chen2021FitnessResults = ({ request }: ResultsProps) => {
       <div>Fitness advantage f_c: {modelData && formatValueWithCI(modelData.params.fc)}</div>
       <div>Fitness advantage f_d: {modelData && formatValueWithCI(modelData.params.fd)}</div>
       <div style={{ height: '300px', marginTop: '20px' }}>
-        <Plot
-          style={{ width: '100%', height: '100%' }}
-          data={[
-            {
-              name: '95% confidence interval',
-              showlegend: false,
-              line: { color: 'transparent' },
-              type: 'scatter',
-              mode: 'lines',
-              x: modelData.plotProportion.t.map(dateString => new Date(dateString)),
-              y: modelData.plotProportion.ciUpper,
-              hoverinfo: 'x',
-            },
-            {
-              name: '95% confidence interval',
-              fill: 'tonexty',
-              fillcolor: 'lightgray',
-              line: { color: 'transparent' },
-              type: 'scatter',
-              mode: 'lines',
-              x: modelData.plotProportion.t.map(dateString => new Date(dateString)),
-              y: modelData.plotProportion.ciLower,
-              hoverinfo: 'x',
-            },
-            {
-              name: 'Logistic fit',
-              type: 'scatter',
-              mode: 'lines',
-              x: modelData.plotProportion.t.map(dateString => new Date(dateString)),
-              y: modelData.plotProportion.proportion,
-              text: plotProportionText,
-              hovertemplate: '%{text}',
-            },
-            {
-              name: 'Estimated daily proportion',
-              type: 'scatter',
-              mode: 'markers',
-              marker: {
-                size: 4,
-              },
-              text: filteredDailyText,
-              hovertemplate: '%{text}',
-              x: filteredDaily.t.map(dateString => new Date(dateString)),
-              y: filteredDaily.proportion,
-            },
-          ]}
-          layout={{
-            title: 'Estimated proportion through time',
-            xaxis: {
-              hoverformat: '%d.%m.%Y',
-            },
-          }}
-          config={{
-            displaylogo: false,
-            modeBarButtons: [['zoom2d', 'toImage', 'resetScale2d', 'pan2d']],
-            responsive: true,
-          }}
-        />
+        {
+          <Chen2021ProportionPlot
+            modelData={modelData}
+            plotStartDate={request.plotStartDate}
+            plotEndDate={request.plotEndDate}
+          />
+        }
       </div>
       <div style={{ height: '300px', marginTop: '20px' }}>
-        <Plot
-          style={{ width: '100%', height: '100%' }}
-          data={[
-            {
-              name: 'Wildtype',
-              type: 'scatter',
-              mode: 'lines',
-              x: modelData.plotProportion.t.map(dateString => new Date(dateString)),
-              y: modelData.plotAbsoluteNumbers.wildtypeCases,
-              stackgroup: 'one',
-            },
-            {
-              name: 'Variant',
-              type: 'scatter',
-              mode: 'lines',
-              x: modelData.plotProportion.t.map(dateString => new Date(dateString)),
-              y: modelData.plotAbsoluteNumbers.variantCases,
-              stackgroup: 'one',
-            },
-          ]}
-          layout={{
-            title: 'Changes in absolute case numbers through time',
-            xaxis: {
-              hoverformat: '%d.%m.%Y',
-            },
-          }}
-          config={{
-            displaylogo: false,
-            modeBarButtons: [['zoom2d', 'toImage', 'resetScale2d', 'pan2d']],
-            responsive: true,
-          }}
-        />
+        <Chen2021AbsolutePlot modelData={modelData} />
       </div>
     </>
   );

--- a/src/models/chen2021Fitness/Chen2021ProportionPlot.tsx
+++ b/src/models/chen2021Fitness/Chen2021ProportionPlot.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import * as zod from 'zod';
+import { Plot } from '../../components/Plot';
+import { Chen2021FitnessResponse, Chen2021FitnessResponseSchema } from './chen2021Fitness-types';
+import { formatValueWithCI } from './format-value';
+
+interface Props {
+  modelData: Chen2021FitnessResponse;
+  plotStartDate: Date;
+  plotEndDate: Date;
+}
+
+export const Chen2021ProportionPlot = ({ modelData, plotStartDate, plotEndDate }: Props) => {
+  const filteredDaily: zod.infer<typeof Chen2021FitnessResponseSchema.shape.daily> = {
+    t: [],
+    proportion: [],
+    ciLower: [],
+    ciUpper: [],
+  };
+  const filteredDailyText = [];
+  const daily = modelData.daily;
+  for (let i = 0; i < daily.t.length; i++) {
+    const d = new Date(daily.t[i]);
+    if (d >= plotStartDate && d <= plotEndDate) {
+      filteredDaily.t.push(daily.t[i]);
+      filteredDaily.proportion.push(daily.proportion[i]);
+      filteredDaily.ciLower.push(daily.ciLower[i]);
+      filteredDaily.ciUpper.push(daily.ciUpper[i]);
+      filteredDailyText.push(
+        formatValueWithCI(
+          {
+            value: daily.proportion[i],
+            ciLower: daily.ciLower[i],
+            ciUpper: daily.ciUpper[i],
+          },
+          2,
+          true
+        )
+      );
+    }
+  }
+
+  const plotProportionText = [];
+  const plotProportion = modelData.plotProportion;
+  for (let i = 0; i < plotProportion.t.length; i++) {
+    plotProportionText.push(
+      formatValueWithCI(
+        {
+          value: plotProportion.proportion[i],
+          ciLower: plotProportion.ciLower[i],
+          ciUpper: plotProportion.ciUpper[i],
+        },
+        2,
+        true
+      )
+    );
+  }
+
+  return (
+    <Plot
+      style={{ width: '100%', height: '100%' }}
+      data={[
+        {
+          name: '95% confidence interval',
+          showlegend: false,
+          line: { color: 'transparent' },
+          type: 'scatter',
+          mode: 'lines',
+          x: modelData.plotProportion.t.map(dateString => new Date(dateString)),
+          y: modelData.plotProportion.ciUpper,
+          hoverinfo: 'x',
+        },
+        {
+          name: '95% confidence interval',
+          fill: 'tonexty',
+          fillcolor: 'lightgray',
+          line: { color: 'transparent' },
+          type: 'scatter',
+          mode: 'lines',
+          x: modelData.plotProportion.t.map(dateString => new Date(dateString)),
+          y: modelData.plotProportion.ciLower,
+          hoverinfo: 'x',
+        },
+        {
+          name: 'Logistic fit',
+          type: 'scatter',
+          mode: 'lines',
+          x: modelData.plotProportion.t.map(dateString => new Date(dateString)),
+          y: modelData.plotProportion.proportion,
+          text: plotProportionText,
+          hovertemplate: '%{text}',
+        },
+        {
+          name: 'Estimated daily proportion',
+          type: 'scatter',
+          mode: 'markers',
+          marker: {
+            size: 4,
+          },
+          text: filteredDailyText,
+          hovertemplate: '%{text}',
+          x: filteredDaily.t.map(dateString => new Date(dateString)),
+          y: filteredDaily.proportion,
+        },
+      ]}
+      layout={{
+        title: 'Estimated proportion through time',
+        xaxis: {
+          hoverformat: '%d.%m.%Y',
+        },
+      }}
+      config={{
+        displaylogo: false,
+        modeBarButtons: [['zoom2d', 'toImage', 'resetScale2d', 'pan2d']],
+        responsive: true,
+      }}
+    />
+  );
+};

--- a/src/models/chen2021Fitness/chen2021Fitness-types.ts
+++ b/src/models/chen2021Fitness/chen2021Fitness-types.ts
@@ -45,3 +45,6 @@ export const Chen2021FitnessResponseSchema = zod.object({
     ciUpper: zod.array(zod.number()),
   }),
 });
+
+export type ValueWithCI = zod.infer<typeof ValueWithCISchema>;
+export type Chen2021FitnessResponse = zod.infer<typeof Chen2021FitnessResponseSchema>;

--- a/src/models/chen2021Fitness/format-value.ts
+++ b/src/models/chen2021Fitness/format-value.ts
@@ -1,0 +1,18 @@
+import { ValueWithCI } from './chen2021Fitness-types';
+
+export const formatValueWithCI = (
+  { value, ciLower, ciUpper }: ValueWithCI,
+  fractionDigits = 4,
+  usePercentSign = false
+) => {
+  if (usePercentSign) {
+    return (
+      `${(value * 100).toFixed(fractionDigits)}% ` +
+      `[${(ciLower * 100).toFixed(fractionDigits)}%, ${(ciUpper * 100).toFixed(fractionDigits)}%]`
+    );
+  } else {
+    return `${value.toFixed(fractionDigits)} [${ciLower.toFixed(fractionDigits)}, ${ciUpper.toFixed(
+      fractionDigits
+    )}]`;
+  }
+};

--- a/src/models/chen2021Fitness/loading.ts
+++ b/src/models/chen2021Fitness/loading.ts
@@ -1,0 +1,101 @@
+import {
+  Chen2021FitnessRequest,
+  Chen2021FitnessResponse,
+  Chen2021FitnessResponseSchema,
+} from './chen2021Fitness-types';
+import * as zod from 'zod';
+import { SampleSelectorSchema } from '../../helpers/sample-selector';
+import { useEffect, useState } from 'react';
+import { get } from '../../services/api';
+
+export function fillRequestWithDefaults({
+  country,
+  mutations,
+  matchPercentage,
+  samplingStrategy,
+}: zod.infer<typeof SampleSelectorSchema>): Chen2021FitnessRequest {
+  return {
+    country,
+    mutations,
+    matchPercentage,
+    samplingStrategy,
+    alpha: 0.95,
+    generationTime: 4.8,
+    reproductionNumberWildtype: 1,
+    plotStartDate: new Date('2021-01-01'),
+    plotEndDate: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000),
+    initialWildtypeCases: 1000,
+    initialVariantCases: 100,
+  };
+}
+
+const getData = async (
+  params: Chen2021FitnessRequest,
+  signal: AbortSignal
+): Promise<Chen2021FitnessResponse | undefined> => {
+  const mutationsString = params.mutations.join(',');
+  const urlSearchParams = new URLSearchParams({
+    country: params.country,
+    mutations: mutationsString,
+    matchPercentage: params.matchPercentage.toString(),
+    alpha: params.alpha.toString(),
+    generationTime: params.generationTime.toString(),
+    reproductionNumberWildtype: params.reproductionNumberWildtype.toString(),
+    plotStartDate: params.plotStartDate.toISOString().substring(0, 10),
+    plotEndDate: params.plotEndDate.toISOString().substring(0, 10),
+    initialWildtypeCases: params.initialWildtypeCases.toString(),
+    initialVariantCases: params.initialVariantCases.toString(),
+  });
+  if (params.samplingStrategy) {
+    urlSearchParams.set('dataType', params.samplingStrategy);
+  }
+  const url = `/computed/model/chen2021Fitness?` + urlSearchParams.toString();
+  const response = await get(url, signal);
+  if (response.status !== 200) {
+    // The computation might fail, for example, if some values go out-of-bound. The issue shall be addressed with the
+    // introduction of a better error handling and reporting on the server side.
+    return undefined;
+  }
+  const data = await response.json();
+  if (!data) {
+    return undefined;
+  }
+  return Chen2021FitnessResponseSchema.parse(data);
+};
+
+interface ModelDataResult {
+  modelData?: Chen2021FitnessResponse;
+  loading: boolean;
+}
+
+export function useModelData(request: Chen2021FitnessRequest): ModelDataResult {
+  const [result, setResult] = useState<ModelDataResult>({ loading: true });
+
+  useEffect(() => {
+    let isSubscribed = true;
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    setResult({ loading: true });
+
+    getData(request, signal)
+      .then(modelData => {
+        if (isSubscribed) {
+          setResult({ modelData, loading: false });
+        }
+      })
+      .catch(e => {
+        console.log('Called fetch data error', e);
+        if (isSubscribed) {
+          setResult({ loading: false });
+        }
+      });
+
+    return () => {
+      isSubscribed = false;
+      controller.abort();
+    };
+  }, [request]);
+
+  return result;
+}

--- a/src/pages/DeepFocusPage.tsx
+++ b/src/pages/DeepFocusPage.tsx
@@ -53,7 +53,7 @@ export const DeepFocusPage = (props: Props) => {
         <VariantHeader
           variant={variant}
           controls={
-            <Button variant='outline-secondary' as={Link} to={url}>
+            <Button variant='secondary' as={Link} to={url}>
               Back to overview
             </Button>
           }

--- a/src/pages/DeepFocusPage.tsx
+++ b/src/pages/DeepFocusPage.tsx
@@ -3,6 +3,7 @@ import { Button } from 'react-bootstrap';
 import { Route, useRouteMatch, Switch } from 'react-router';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { InternationalComparison } from '../components/InternationalComparison';
 import { SampleTable } from '../components/SampleTable';
 import { VariantHeader } from '../components/VariantHeader';
 import { scrollableContainerPaddingPx, scrollableContainerStyle } from '../helpers/scrollable-container';
@@ -44,6 +45,11 @@ export const DeepFocusPage = (props: Props) => {
       key: 'samples',
       title: 'Samples',
       content: <SampleTable {...props} />,
+    },
+    {
+      key: 'international-comparison',
+      title: 'International comparison',
+      content: <InternationalComparison {...props} />,
     },
   ];
 

--- a/src/pages/DeepFocusPage.tsx
+++ b/src/pages/DeepFocusPage.tsx
@@ -4,10 +4,12 @@ import { Route, useRouteMatch, Switch } from 'react-router';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { InternationalComparison } from '../components/InternationalComparison';
+import { MinimalWidgetLayout } from '../components/MinimalWidgetLayout';
 import { SampleTable } from '../components/SampleTable';
 import { VariantHeader } from '../components/VariantHeader';
 import { scrollableContainerPaddingPx, scrollableContainerStyle } from '../helpers/scrollable-container';
-import { SamplingStrategy } from '../services/api';
+import { Chen2021FitnessWidget } from '../models/chen2021Fitness/Chen2021FitnessWidget';
+import { SamplingStrategy, toLiteralSamplingStrategy } from '../services/api';
 import { Country, Variant } from '../services/api-types';
 
 interface Props {
@@ -40,6 +42,13 @@ export const DeepFocusPage = (props: Props) => {
 
   const { path, url } = useRouteMatch();
 
+  const plotProps = {
+    country: props.country,
+    matchPercentage: props.matchPercentage,
+    mutations: props.variant.mutations,
+    samplingStrategy: toLiteralSamplingStrategy(props.samplingStrategy),
+  };
+
   const routes = [
     {
       key: 'samples',
@@ -50,6 +59,17 @@ export const DeepFocusPage = (props: Props) => {
       key: 'international-comparison',
       title: 'International comparison',
       content: <InternationalComparison {...props} />,
+    },
+    {
+      key: 'chen-2021-fitness',
+      title: 'Fitness advantage estimation',
+      content: (
+        <Chen2021FitnessWidget.ShareableComponent
+          {...plotProps}
+          widgetLayout={MinimalWidgetLayout}
+          title='Fitness advantage estimation'
+        />
+      ),
     },
   ];
 

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { Button } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
 import { FocusVariantHeaderControls } from '../components/FocusVariantHeaderControls';
-import { InternationalComparison } from '../components/InternationalComparison';
-import { NamedSection } from '../components/NamedSection';
+import { NamedCard } from '../components/NamedCard';
+import { GridCell, PackedGrid } from '../components/PackedGrid';
 import Switzerland from '../components/Switzerland';
 import { VariantHeader } from '../components/VariantHeader';
+import { getFocusPageLink } from '../helpers/explore-url';
+import { Chen2021FitnessWidget } from '../models/chen2021Fitness/Chen2021FitnessWidget';
 import { SamplingStrategy, toLiteralSamplingStrategy } from '../services/api';
 import { Country, Variant } from '../services/api-types';
 import { VariantAgeDistributionPlotWidget } from '../widgets/VariantAgeDistributionPlot';
+import { VariantInternationalComparisonPlotWidget } from '../widgets/VariantInternationalComparisonPlot';
 import { VariantTimeDistributionPlotWidget } from '../widgets/VariantTimeDistributionPlot';
-import { GridCell, PackedGrid } from '../components/PackedGrid';
-import { Chen2021FitnessWidget } from '../models/chen2021Fitness/Chen2021FitnessWidget';
-import { NamedCard } from '../components/NamedCard';
 
 interface Props {
   country: Country;
@@ -21,12 +23,25 @@ interface Props {
 
 export const FocusPage = (props: Props) => {
   const { country, matchPercentage, variant, samplingStrategy } = props;
+
   const plotProps = {
     country,
     matchPercentage,
     mutations: variant.mutations,
     samplingStrategy: toLiteralSamplingStrategy(samplingStrategy),
   };
+
+  const internationalComparisonLink = useMemo(
+    () =>
+      getFocusPageLink({
+        variantSelector: { variant, matchPercentage },
+        country,
+        samplingStrategy,
+        deepFocusPath: '/international-comparison',
+      }),
+    [country, samplingStrategy, matchPercentage, variant]
+  );
+
   return (
     <>
       <VariantHeader variant={variant} controls={<FocusVariantHeaderControls {...props} />} />
@@ -57,11 +72,19 @@ export const FocusPage = (props: Props) => {
           </GridCell>
         )}
         <GridCell>
-          {/*TODO Should we make height optional?*/}
-          <Chen2021FitnessWidget.ShareableComponent {...plotProps} height={-1} title='Models' />
+          <Chen2021FitnessWidget.ShareableComponent {...plotProps} title='Models' />
         </GridCell>
         <GridCell>
-          <InternationalComparison {...props} />
+          <VariantInternationalComparisonPlotWidget.ShareableComponent
+            {...plotProps}
+            height={300}
+            title='International comparison'
+            toolbarChildren={
+              <Button as={Link} to={internationalComparisonLink} size='sm' className='ml-1'>
+                Show more
+              </Button>
+            }
+          />
         </GridCell>
       </PackedGrid>
     </>

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -13,6 +13,7 @@ import { Country, Variant } from '../services/api-types';
 import { VariantAgeDistributionPlotWidget } from '../widgets/VariantAgeDistributionPlot';
 import { VariantInternationalComparisonPlotWidget } from '../widgets/VariantInternationalComparisonPlot';
 import { VariantTimeDistributionPlotWidget } from '../widgets/VariantTimeDistributionPlot';
+import { mapValues } from 'lodash';
 
 interface Props {
   country: Country;
@@ -20,6 +21,11 @@ interface Props {
   variant: Variant;
   samplingStrategy: SamplingStrategy;
 }
+
+const deepFocusPaths = {
+  internationalComparison: '/international-comparison',
+  chen2021Fitness: '/chen-2021-fitness',
+};
 
 export const FocusPage = (props: Props) => {
   const { country, matchPercentage, variant, samplingStrategy } = props;
@@ -31,24 +37,20 @@ export const FocusPage = (props: Props) => {
     samplingStrategy: toLiteralSamplingStrategy(samplingStrategy),
   };
 
-  const internationalComparisonLink = useMemo(
+  const deepFocusButtons = useMemo(
     () =>
-      getFocusPageLink({
-        variantSelector: { variant, matchPercentage },
-        country,
-        samplingStrategy,
-        deepFocusPath: '/international-comparison',
-      }),
-    [country, samplingStrategy, matchPercentage, variant]
-  );
-
-  const chen2021FitnessLink = useMemo(
-    () =>
-      getFocusPageLink({
-        variantSelector: { variant, matchPercentage },
-        country,
-        samplingStrategy,
-        deepFocusPath: '/chen-2021-fitness',
+      mapValues(deepFocusPaths, suffix => {
+        const to = getFocusPageLink({
+          variantSelector: { variant, matchPercentage },
+          country,
+          samplingStrategy,
+          deepFocusPath: suffix,
+        });
+        return (
+          <Button as={Link} to={to} size='sm' className='ml-1'>
+            Show more
+          </Button>
+        );
       }),
     [country, samplingStrategy, matchPercentage, variant]
   );
@@ -83,15 +85,8 @@ export const FocusPage = (props: Props) => {
           </GridCell>
         )}
         <GridCell>
-          <NamedCard
-            title='Fitness advantage estimation'
-            toolbar={
-              <Button as={Link} to={chen2021FitnessLink} size='sm' className='ml-1'>
-                Show more
-              </Button>
-            }
-          >
-            <div style={{ height: 400 }}>
+          <NamedCard title='Fitness advantage estimation' toolbar={deepFocusButtons.chen2021Fitness}>
+            <div style={{ height: 300 }}>
               <Chen2021FitnessPreview {...plotProps} />
             </div>
           </NamedCard>
@@ -101,11 +96,7 @@ export const FocusPage = (props: Props) => {
             {...plotProps}
             height={300}
             title='International comparison'
-            toolbarChildren={
-              <Button as={Link} to={internationalComparisonLink} size='sm' className='ml-1'>
-                Show more
-              </Button>
-            }
+            toolbarChildren={deepFocusButtons.internationalComparison}
           />
         </GridCell>
       </PackedGrid>

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -7,7 +7,7 @@ import { GridCell, PackedGrid } from '../components/PackedGrid';
 import Switzerland from '../components/Switzerland';
 import { VariantHeader } from '../components/VariantHeader';
 import { getFocusPageLink } from '../helpers/explore-url';
-import { Chen2021FitnessWidget } from '../models/chen2021Fitness/Chen2021FitnessWidget';
+import { Chen2021FitnessPreview } from '../models/chen2021Fitness/Chen2021FitnessPreview';
 import { SamplingStrategy, toLiteralSamplingStrategy } from '../services/api';
 import { Country, Variant } from '../services/api-types';
 import { VariantAgeDistributionPlotWidget } from '../widgets/VariantAgeDistributionPlot';
@@ -42,6 +42,17 @@ export const FocusPage = (props: Props) => {
     [country, samplingStrategy, matchPercentage, variant]
   );
 
+  const chen2021FitnessLink = useMemo(
+    () =>
+      getFocusPageLink({
+        variantSelector: { variant, matchPercentage },
+        country,
+        samplingStrategy,
+        deepFocusPath: '/chen-2021-fitness',
+      }),
+    [country, samplingStrategy, matchPercentage, variant]
+  );
+
   return (
     <>
       <VariantHeader variant={variant} controls={<FocusVariantHeaderControls {...props} />} />
@@ -72,7 +83,18 @@ export const FocusPage = (props: Props) => {
           </GridCell>
         )}
         <GridCell>
-          <Chen2021FitnessWidget.ShareableComponent {...plotProps} title='Fitness advantage estimation' />
+          <NamedCard
+            title='Fitness advantage estimation'
+            toolbar={
+              <Button as={Link} to={chen2021FitnessLink} size='sm' className='ml-1'>
+                Show more
+              </Button>
+            }
+          >
+            <div style={{ height: 400 }}>
+              <Chen2021FitnessPreview {...plotProps} />
+            </div>
+          </NamedCard>
         </GridCell>
         <GridCell>
           <VariantInternationalComparisonPlotWidget.ShareableComponent

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -78,20 +78,20 @@ export const FocusPage = (props: Props) => {
           />
         </GridCell>
         {props.country === 'Switzerland' && (
-          <GridCell>
+          <GridCell minWidth={600}>
             <NamedCard title='Geography'>
               <Switzerland {...plotProps} />
             </NamedCard>
           </GridCell>
         )}
-        <GridCell>
+        <GridCell minWidth={600}>
           <NamedCard title='Fitness advantage estimation' toolbar={deepFocusButtons.chen2021Fitness}>
             <div style={{ height: 300 }}>
               <Chen2021FitnessPreview {...plotProps} />
             </div>
           </NamedCard>
         </GridCell>
-        <GridCell>
+        <GridCell minWidth={600}>
           <VariantInternationalComparisonPlotWidget.ShareableComponent
             {...plotProps}
             height={300}

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -72,7 +72,7 @@ export const FocusPage = (props: Props) => {
           </GridCell>
         )}
         <GridCell>
-          <Chen2021FitnessWidget.ShareableComponent {...plotProps} title='Models' />
+          <Chen2021FitnessWidget.ShareableComponent {...plotProps} title='Fitness advantage estimation' />
         </GridCell>
         <GridCell>
           <VariantInternationalComparisonPlotWidget.ShareableComponent

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -10,6 +10,7 @@ import { VariantAgeDistributionPlotWidget } from '../widgets/VariantAgeDistribut
 import { VariantTimeDistributionPlotWidget } from '../widgets/VariantTimeDistributionPlot';
 import { GridCell, PackedGrid } from '../components/PackedGrid';
 import { Chen2021FitnessWidget } from '../models/chen2021Fitness/Chen2021FitnessWidget';
+import { NamedCard } from '../components/NamedCard';
 
 interface Props {
   country: Country;
@@ -35,32 +36,32 @@ export const FocusPage = (props: Props) => {
       </p>
       <PackedGrid>
         <GridCell minWidth={800}>
-          <NamedSection title='Sequences over time'>
-            <VariantTimeDistributionPlotWidget.ShareableComponent {...plotProps} height={300} />
-          </NamedSection>
+          <VariantTimeDistributionPlotWidget.ShareableComponent
+            {...plotProps}
+            height={300}
+            title='Sequences over time'
+          />
         </GridCell>
         <GridCell minWidth={400}>
-          <NamedSection title='Demographics'>
-            <VariantAgeDistributionPlotWidget.ShareableComponent {...plotProps} height={300} />
-          </NamedSection>
+          <VariantAgeDistributionPlotWidget.ShareableComponent
+            {...plotProps}
+            height={300}
+            title='Demographics'
+          />
         </GridCell>
         {props.country === 'Switzerland' && (
           <GridCell>
-            <NamedSection title='Geography'>
+            <NamedCard title='Geography'>
               <Switzerland {...plotProps} />
-            </NamedSection>
+            </NamedCard>
           </GridCell>
         )}
         <GridCell>
-          <NamedSection title='Models'>
-            {/*TODO Should we make height optional?*/}
-            <Chen2021FitnessWidget.ShareableComponent {...plotProps} height={-1} />
-          </NamedSection>
+          {/*TODO Should we make height optional?*/}
+          <Chen2021FitnessWidget.ShareableComponent {...plotProps} height={-1} title='Models' />
         </GridCell>
         <GridCell>
-          <NamedSection title='International comparison'>
-            <InternationalComparison {...props} />
-          </NamedSection>
+          <InternationalComparison {...props} />
         </GridCell>
       </PackedGrid>
     </>

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -62,15 +62,15 @@ export const FocusPage = (props: Props) => {
         The following plots show sequences matching <b>{Math.round(matchPercentage * 100)}%</b> of the
         mutations.
       </p>
-      <PackedGrid>
-        <GridCell minWidth={800}>
+      <PackedGrid maxColumns={2}>
+        <GridCell minWidth={600}>
           <VariantTimeDistributionPlotWidget.ShareableComponent
             {...plotProps}
             height={300}
             title='Sequences over time'
           />
         </GridCell>
-        <GridCell minWidth={400}>
+        <GridCell minWidth={600}>
           <VariantAgeDistributionPlotWidget.ShareableComponent
             {...plotProps}
             height={300}

--- a/src/widgets/VariantInternationalComparisonPlot.tsx
+++ b/src/widgets/VariantInternationalComparisonPlot.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import * as zod from 'zod';
+import Loader from '../components/Loader';
 import { Plot } from '../components/Plot';
 import { EntryWithoutCI, removeCIFromEntry } from '../helpers/confidence-interval';
 import { fillGroupedWeeklyApiData } from '../helpers/fill-missing';
@@ -77,7 +78,7 @@ const VariantInternationalComparisonPlot = ({ country, mutations, matchPercentag
 
   return (
     <div style={{ height: '100%' }}>
-      {!filteredPlotData && <p>Loading...</p>}
+      {!filteredPlotData && <Loader />}
       {filteredPlotData && (
         <Plot
           style={{ width: '100%', height: '100%' }}


### PR DESCRIPTION
This PR makes the major structural parts of the style changes that I presented at the last meeting:

  - Add cards around the things on the focus page
  - Move most of "Fitness advantange estimation" and "International comparison" to deep focus pages

Note that this PR on purpose does not make (most) cosmetic changes to the style (colors, shadows, etc). I'll do those in a future PR (see issue https://github.com/cevo-public/cov-spectrum-website/issues/73).

Please tell me if you notice any general issues or bugs with the restructured UI. I'm not really asking for technical feedback, since structural changes are tough to read in a PR.