### PR TITLE
Relative hospitalization

### DIFF
--- a/src/charts/GroupedProportionComparisonChart.tsx
+++ b/src/charts/GroupedProportionComparisonChart.tsx
@@ -109,11 +109,23 @@ export type Props = {
   width: number;
   height: number;
   extendedMetrics?: boolean;
+  rawY?: boolean;
+  hideReferenceScatter?: boolean;
   onClickHandler?: OnClickHandler;
 };
 
 export const GroupedProportionComparisonChart = React.memo(
-  ({ data, total, texts, width, height, extendedMetrics, onClickHandler }: Props): JSX.Element => {
+  ({
+    data,
+    total,
+    texts,
+    width,
+    height,
+    extendedMetrics,
+    rawY,
+    hideReferenceScatter,
+    onClickHandler,
+  }: Props): JSX.Element => {
     const [currentData, setCurrentData] = useState<GroupValue | undefined>();
 
     useEffect(() => {
@@ -212,33 +224,37 @@ export const GroupedProportionComparisonChart = React.memo(
                 dataKey='y'
                 axisLine={false}
                 tickLine={false}
-                domain={[0, (dataMax: number) => Math.min(1, Math.ceil(dataMax * 10) / 10)]}
+                domain={
+                  rawY ? undefined : [0, (dataMax: number) => Math.min(1, Math.ceil(dataMax * 10) / 10)]
+                }
                 scale='linear'
-                tickFormatter={v => `${(v * 100).toFixed(0)}%`}
+                tickFormatter={rawY ? undefined : v => `${(v * 100).toFixed(0)}%`}
               />
               <CartesianGrid vertical={false} />
               <Bar {...commonProps} dataKey='y' fill='transparent' />
-              <Scatter
-                {...commonProps}
-                data={makeScatterData('reference', {
-                  active: colors.inactive,
-                  inactive: colors.inactive,
-                })}
-                shape={ScatterBarShape}
-              >
-                <ErrorBar
-                  direction='y'
-                  dataKey='yErrorActive'
-                  stroke={colors.inactive}
-                  {...referenceErrorBarSizes}
-                />
-                <ErrorBar
-                  direction='y'
-                  dataKey='yErrorInactive'
-                  stroke={colors.inactive}
-                  {...referenceErrorBarSizes}
-                />
-              </Scatter>
+              {!hideReferenceScatter && (
+                <Scatter
+                  {...commonProps}
+                  data={makeScatterData('reference', {
+                    active: colors.inactive,
+                    inactive: colors.inactive,
+                  })}
+                  shape={ScatterBarShape}
+                >
+                  <ErrorBar
+                    direction='y'
+                    dataKey='yErrorActive'
+                    stroke={colors.inactive}
+                    {...referenceErrorBarSizes}
+                  />
+                  <ErrorBar
+                    direction='y'
+                    dataKey='yErrorInactive'
+                    stroke={colors.inactive}
+                    {...referenceErrorBarSizes}
+                  />
+                </Scatter>
+              )}
               <Scatter
                 {...commonProps}
                 data={makeScatterData('subject', { active: colors.active, inactive: colors.inactive })}

--- a/src/components/HospitalizationDeathDeepFocus.tsx
+++ b/src/components/HospitalizationDeathDeepFocus.tsx
@@ -14,6 +14,10 @@ interface Props {
   variantName: string;
 }
 
+const Toolbar = styled.div`
+  margin: 15px;
+`;
+
 const Info = styled.div`
   margin: 15px;
 `;
@@ -24,6 +28,8 @@ export const HospitalizationDeathDeepFocus = ({
   wholeSampleSet,
   variantName,
 }: Props) => {
+  const [relative, setRelative] = useState(false);
+
   if (country !== 'Switzerland') {
     return <Alert variant='danger'>Hospitalization and death rates are only available for Switzerland</Alert>;
   }
@@ -39,7 +45,7 @@ export const HospitalizationDeathDeepFocus = ({
               wholeSampleSet={wholeSampleSet}
               variantName={variantName}
               extendedMetrics
-              relativeToOtherVariants
+              relativeToOtherVariants={relative}
             />
           </NamedCard>
         </GridCell>
@@ -51,10 +57,17 @@ export const HospitalizationDeathDeepFocus = ({
               wholeSampleSet={wholeSampleSet}
               variantName={variantName}
               extendedMetrics
+              relativeToOtherVariants={relative}
             />
           </NamedCard>
         </GridCell>
       </PackedGrid>
+
+      <Toolbar>
+        <Button variant='secondary' onClick={() => setRelative(v => !v)}>
+          Show {relative ? 'absolute' : 'relative'} data
+        </Button>
+      </Toolbar>
 
       <Info>
         <p>

--- a/src/components/HospitalizationDeathDeepFocus.tsx
+++ b/src/components/HospitalizationDeathDeepFocus.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Alert } from 'react-bootstrap';
+import React, { useState } from 'react';
+import { Alert, Button } from 'react-bootstrap';
 import styled from 'styled-components';
 import { SampleSetWithSelector } from '../helpers/sample-set';
 import { Country } from '../services/api-types';
@@ -72,17 +72,33 @@ export const HospitalizationDeathDeepFocus = ({
       <Info>
         <p>
           These plots show the rates of hospitalization and death reported in connection with SARS-CoV-2
-          samples.
+          samples.{' '}
+          {relative && (
+            <>
+              The Y value represents the probability of hospitalization/death in connection with {variantName}{' '}
+              samples, relative to the probability in connection with samples from other variants. It is
+              calculated as (rate {variantName}) / (rate for other variants).
+            </>
+          )}
         </p>
         <p>The following samples are omitted from the plots:</p>
         <ul>
           <li>Samples from the last {OMIT_LAST_N_WEEKS} weeks</li>
           <li>Samples for which no hospitalization or death outcome is known</li>
         </ul>
-        <p>
-          The error bars show Wilson score intervals with 95% confidence assuming that the measured outcomes
-          are binomially distributed.
-        </p>
+        {relative ? (
+          <p>
+            The error bars show 95% confidence intervals where the data is modeled as the ratio of two
+            binomial proportions. These intervals are approximated using the method from "Obtaining Confidence
+            Intervals for the Risk Ratio in Cohort Studies" (Katz et al., 1978, Biometrics 34, 469-474). Some
+            very wide error bars may be cut off.
+          </p>
+        ) : (
+          <p>
+            The error bars show Wilson score intervals with 95% confidence assuming that the measured outcomes
+            are binomially distributed.
+          </p>
+        )}
       </Info>
     </>
   );

--- a/src/components/HospitalizationDeathDeepFocus.tsx
+++ b/src/components/HospitalizationDeathDeepFocus.tsx
@@ -39,6 +39,7 @@ export const HospitalizationDeathDeepFocus = ({
               wholeSampleSet={wholeSampleSet}
               variantName={variantName}
               extendedMetrics
+              relativeToOtherVariants
             />
           </NamedCard>
         </GridCell>

--- a/src/helpers/__tests__/binomial-ratio-confidence.test.ts
+++ b/src/helpers/__tests__/binomial-ratio-confidence.test.ts
@@ -1,0 +1,26 @@
+import { approximateBinomialRatioConfidence } from '../binomial-ratio-confidence';
+
+test('approximateBinomialRatioConfidence', () => {
+  interface Case {
+    x: number;
+    m: number;
+    y: number;
+    n: number;
+    low: number;
+    high: number;
+  }
+  const cases: Case[] = [
+    { x: 21, m: 91, y: 114, n: 1158, low: 1.55004024, high: 3.54503271 },
+    { x: 0, m: 91, y: 0, n: 1158, low: 0, high: Infinity },
+    { x: 0, m: 0, y: 0, n: 0, low: 0, high: Infinity },
+    { x: 0, m: 91, y: 114, n: 1158, low: 0, high: 0.89040097 },
+    { x: 21, m: 91, y: 0, n: 1158, low: 32.61516936, high: Infinity },
+    { x: 91, m: 91, y: 1158, n: 1158, low: 0.97981025, high: 1.0102934 },
+  ];
+
+  for (const c of cases) {
+    const [low, high] = approximateBinomialRatioConfidence(c.x, c.m, c.y, c.n);
+    expect(low).toBeCloseTo(c.low, 5);
+    expect(high).toBeCloseTo(c.high, 5);
+  }
+});

--- a/src/helpers/__tests__/binomial-ratio-confidence.test.ts
+++ b/src/helpers/__tests__/binomial-ratio-confidence.test.ts
@@ -16,6 +16,11 @@ test('approximateBinomialRatioConfidence', () => {
     { x: 0, m: 91, y: 114, n: 1158, low: 0, high: 0.89040097 },
     { x: 21, m: 91, y: 0, n: 1158, low: 32.61516936, high: Infinity },
     { x: 91, m: 91, y: 1158, n: 1158, low: 0.97981025, high: 1.0102934 },
+
+    // These cases are not so meaningful, but at least they should not crash
+    { x: 0, m: 0, y: 114, n: 1158, low: 0, high: Infinity },
+    { x: 21, m: 91, y: 0, n: 0, low: 0, high: Infinity },
+    { x: 0.25, m: 0.25, y: 0.4, n: 0.4, low: 0, high: Infinity },
   ];
 
   for (const c of cases) {

--- a/src/helpers/binomial-ratio-confidence.ts
+++ b/src/helpers/binomial-ratio-confidence.ts
@@ -1,0 +1,44 @@
+import assert from 'assert';
+
+// approximateBinomialRatioConfidence calculates the 95% confidence interval of
+// the ratio of two measured proportions, where each proportion is calculated
+// from a measured binomially distributed random variable.
+//
+// Original paper:
+// "Obtaining Confidence Intervals for the Risk Ratio in Cohort Studies" (Katz et al., 1978, Biometrics 34, 469-474)
+//
+// Shorter description:
+// "Confidence Intervals for the Ratio of Two Binomial Proportions" (Koopman 1984, Biometrics 40, 513-517)
+//
+// R implementation:
+// https://github.com/cran/DescTools/blob/62a71ebdfc239988ad02d5c2feed2b9d2645b97d/R/StatsAndCIs.r#L3164
+//
+// x - number of successes for the ratio numerator
+// m - number of trials for the ratio numerator
+// y - number of successes for the ratio denominator
+// n - number of trials for the ratio denominator
+// alpha - confidence level (between 0 and 1)
+export function approximateBinomialRatioConfidence(
+  x: number,
+  m: number,
+  y: number,
+  n: number
+): [number, number] {
+  assert(x >= 0 && x <= m);
+  assert(y >= 0 && y <= n);
+
+  if (x === 0 && y === 0) {
+    return [0, Infinity];
+  } else if (x === 0) {
+    return [0, approximateBinomialRatioConfidence(0.5, m, y, n)[1]];
+  } else if (y === 0) {
+    return [approximateBinomialRatioConfidence(x, m, 0.5, n)[0], Infinity];
+  } else if (x === m && y === n) {
+    return approximateBinomialRatioConfidence(m - 0.5, m, n - 0.5, n);
+  }
+
+  const t = x / m / (y / n);
+  const eta = 1.959963984540054; // scipy.stats.norm.ppf(1 - (1 - 0.95) / 2)
+  const stddev = Math.sqrt(1 / x - 1 / m + 1 / y - 1 / n);
+  return [t * Math.exp(-eta * stddev), t * Math.exp(eta * stddev)];
+}

--- a/src/helpers/binomial-ratio-confidence.ts
+++ b/src/helpers/binomial-ratio-confidence.ts
@@ -27,7 +27,12 @@ export function approximateBinomialRatioConfidence(
   assert(x >= 0 && x <= m);
   assert(y >= 0 && y <= n);
 
-  if (x === 0 && y === 0) {
+  if (
+    (x === 0 && y === 0) ||
+    (x === 0 && m < 0.5) ||
+    (y === 0 && n < 0.5) ||
+    (x === m && y === n && (x < 0.5 || y < 0.5))
+  ) {
     return [0, Infinity];
   } else if (x === 0) {
     return [0, approximateBinomialRatioConfidence(0.5, m, y, n)[1]];

--- a/src/widgets/HospitalizationDeathPlot.tsx
+++ b/src/widgets/HospitalizationDeathPlot.tsx
@@ -54,14 +54,21 @@ const makeDeceasedTexts = (variant: string): SubgroupTexts => ({
   },
 });
 
-const makeTexts = (variantName: string): { hospitalized: TopLevelTexts; deceased: TopLevelTexts } => ({
+const makeTexts = (
+  variantName: string,
+  relativeToOtherVariants: boolean
+): { hospitalized: TopLevelTexts; deceased: TopLevelTexts } => ({
   hospitalized: {
-    title: 'Estimated hospitalization probabilities by age group',
+    title:
+      'Estimated hospitalization probabilities by age group' +
+      (relativeToOtherVariants ? ', relative to other variants' : ''),
     subject: makeHospitalizedTexts(variantName),
     reference: makeHospitalizedTexts('other variants'),
   },
   deceased: {
-    title: 'Estimated death probabilities by age group',
+    title:
+      'Estimated death probabilities by age group' +
+      (relativeToOtherVariants ? ', relative to other variants' : ''),
     subject: makeDeceasedTexts(variantName),
     reference: makeDeceasedTexts('other variants'),
   },
@@ -136,7 +143,7 @@ export const HospitalizationDeathPlot = ({
   field,
   variantName,
   extendedMetrics,
-  relativeToOtherVariants,
+  relativeToOtherVariants = false,
 }: Props) => {
   const { width, height, ref } = useResizeDetector();
   const widthIsSmall = !!width && width < 700;
@@ -216,7 +223,7 @@ export const HospitalizationDeathPlot = ({
     return total;
   }, [processedData]);
 
-  const texts = makeTexts(variantName)[field];
+  const texts = makeTexts(variantName, relativeToOtherVariants)[field];
 
   return (
     <DownloadWrapper name='HospitalizationDeathPlot' rawData={processedData} dataProcessor={dataProcessor}>
@@ -232,7 +239,15 @@ export const HospitalizationDeathPlot = ({
               height={height}
               extendedMetrics={extendedMetrics}
               onClickHandler={noopOnClickHandler}
-              rawY={relativeToOtherVariants}
+              maxY={
+                relativeToOtherVariants
+                  ? Math.max(
+                      ...processedData
+                        .filter(v => v.subject.proportion)
+                        .map(v => v.subject.proportion!.value * 2)
+                    ) || 5
+                  : undefined
+              }
               hideReferenceScatter={relativeToOtherVariants}
             />
           </>


### PR DESCRIPTION
This closes #100.

I ended up not hiding data points with very wide confidence intervals. Instead the max of the Y axis is set 2 times the largest Y data point (excluding error bars), so very wide error bars will be cut off. This is explained in the text below the plot and is also intuitively visible since the little horizontal bits of the bars are hidden in that case.