### PR TITLE
Feature/estimated case numbers

### DIFF
--- a/src/charts/EstimatedCasesChart.tsx
+++ b/src/charts/EstimatedCasesChart.tsx
@@ -1,0 +1,195 @@
+import React, { useMemo, useState } from 'react';
+import { UnifiedDay } from '../helpers/date-cache';
+import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from './common';
+import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import Metric, { MetricsSpacing, MetricsWrapper } from './Metrics';
+import { getTicks } from '../models/wasteWater/WasteWaterTimeChart';
+import calculateWilsonInterval from 'wilson-interval';
+
+export type EstimatedCasesTimeEntry = {
+  date: UnifiedDay;
+  cases: number;
+  sequenced: number;
+  variantCount: number;
+};
+
+export type EstimatedCasesChartProps = {
+  data: EstimatedCasesTimeEntry[];
+};
+
+type PlotEntry = {
+  date: Date;
+  estimatedCases: number;
+  estimatedCasesCI: [number, number];
+};
+
+export function formatDate(date: number) {
+  const d = new Date(date);
+  return d.getDate() + '.' + (d.getMonth() + 1) + '.' + d.getFullYear();
+}
+
+const CHART_MARGIN_RIGHT = 15;
+
+export const EstimatedCasesChart = React.memo(
+  ({ data }: EstimatedCasesChartProps): JSX.Element => {
+    const [active, setActive] = useState<PlotEntry | undefined>(undefined);
+
+    const {
+      plotData,
+      ticks,
+    }: {
+      plotData: PlotEntry[];
+      ticks: number[];
+    } = useMemo(() => {
+      // Only show the data after the variant was first identified
+      const sortedData = [...data].sort((a, b) => (a.date.dayjs.isAfter(b.date.dayjs) ? 1 : -1));
+      const filteredData: EstimatedCasesTimeEntry[] = [];
+      let firstVariantFound = false;
+      for (let d of sortedData) {
+        if (!firstVariantFound) {
+          if (d.variantCount > 0) {
+            firstVariantFound = true;
+          }
+        }
+        if (firstVariantFound) {
+          filteredData.push(d);
+        }
+      }
+
+      const smoothedData: EstimatedCasesTimeEntry[] = [];
+      for (let i = 3; i < filteredData.length - 3; i++) {
+        const window = [
+          filteredData[i - 3],
+          filteredData[i - 2],
+          filteredData[i - 1],
+          filteredData[i],
+          filteredData[i + 1],
+          filteredData[i + 2],
+          filteredData[i + 3],
+        ];
+        const sum = (accumulator: number, currentValue: number) => accumulator + currentValue;
+        smoothedData.push({
+          date: filteredData[i].date,
+          cases: window.map(d => d.cases).reduce(sum),
+          sequenced: window.map(d => d.sequenced).reduce(sum),
+          variantCount: window.map(d => d.variantCount).reduce(sum),
+        });
+      }
+
+      const plotData: PlotEntry[] = [];
+      for (let { date, cases, sequenced, variantCount } of smoothedData) {
+        if (sequenced === 0) {
+          continue;
+        }
+        const wilsonInterval = calculateWilsonInterval(variantCount, sequenced, false, {
+          confidence: 0.95,
+          precision: 10,
+        });
+        // Math.max(..., 0) compensates for numerical inaccuracies which can lead to negative values.
+        plotData.push({
+          date: date.dayjs.toDate(),
+          estimatedCases: Math.max(variantCount / sequenced, 0) * cases,
+          estimatedCasesCI: [
+            Math.max(+wilsonInterval.low, 0) * cases,
+            Math.max(+wilsonInterval.high, 0) * cases,
+          ],
+        });
+      }
+      const ticks = getTicks(
+        filteredData.map(d => ({
+          date: d.date.dayjs.toDate(),
+        }))
+      );
+      return { plotData, ticks };
+    }, [data]);
+
+    return (
+      <Wrapper>
+        <TitleWrapper>
+          Estimated absolute number of cases
+          {active !== undefined && (
+            <>
+              {' '}
+              on <b>{formatDate(active.date.getTime())}</b>
+            </>
+          )}
+        </TitleWrapper>
+        <ChartAndMetricsWrapper>
+          <ChartWrapper>
+            <ResponsiveContainer>
+              <ComposedChart
+                data={plotData}
+                margin={{ top: 6, right: CHART_MARGIN_RIGHT, left: 0, bottom: 0 }}
+              >
+                <XAxis
+                  dataKey='date'
+                  scale='time'
+                  type='number'
+                  tickFormatter={formatDate}
+                  domain={[
+                    (dataMin: any) => dataMin,
+                    () => data[data.length - 1].date.dayjs.toDate().getTime(),
+                  ]}
+                  ticks={ticks}
+                />
+                <YAxis />
+                <Tooltip
+                  active={false}
+                  content={e => {
+                    if (e.active && e.payload !== undefined) {
+                      const newActive = e.payload[0].payload;
+                      if (active === undefined || active.date.getTime() !== newActive.date.getTime()) {
+                        setActive(newActive);
+                      }
+                    }
+                    if (!e.active) {
+                      setActive(undefined);
+                    }
+                    return <></>;
+                  }}
+                />
+                <Area
+                  type='monotone'
+                  dataKey='estimatedCasesCI'
+                  fill={colors.secondaryLight}
+                  stroke={colors.secondary}
+                  isAnimationActive={false}
+                />
+                <Line
+                  type='monotone'
+                  dataKey='estimatedCases'
+                  stroke={colors.active}
+                  strokeWidth={3}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </ComposedChart>
+            </ResponsiveContainer>
+          </ChartWrapper>
+          <MetricsWrapper>
+            <MetricsSpacing />
+            <Metric
+              value={active !== undefined ? active.estimatedCases.toFixed(0) : 'NA'}
+              title='Est. cases'
+              color={colors.active}
+              helpText='The estimated proportion of the variant multiplied with the number of reported cases (smoothed with a 7-days sliding window)'
+              percent={false}
+            />
+            <Metric
+              value={
+                active !== undefined
+                  ? active.estimatedCasesCI[0].toFixed(0) + '-' + active.estimatedCasesCI[1].toFixed(0)
+                  : 'NA'
+              }
+              fontSize='small'
+              title='Confidence interval'
+              color={colors.active}
+              helpText='The 95% confidence interval'
+              percent={false}
+            />
+          </MetricsWrapper>
+        </ChartAndMetricsWrapper>
+      </Wrapper>
+    );
+  }
+);

--- a/src/charts/EstimatedCasesChart.tsx
+++ b/src/charts/EstimatedCasesChart.tsx
@@ -3,8 +3,8 @@ import { UnifiedDay } from '../helpers/date-cache';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from './common';
 import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import Metric, { MetricsSpacing, MetricsWrapper } from './Metrics';
-import { getTicks } from '../models/wasteWater/WasteWaterTimeChart';
 import calculateWilsonInterval from 'wilson-interval';
+import { getTicks } from '../helpers/ticks';
 
 export type EstimatedCasesTimeEntry = {
   date: UnifiedDay;

--- a/src/charts/EstimatedCasesChart.tsx
+++ b/src/charts/EstimatedCasesChart.tsx
@@ -70,9 +70,9 @@ export const EstimatedCasesChart = React.memo(
         const sum = (accumulator: number, currentValue: number) => accumulator + currentValue;
         smoothedData.push({
           date: filteredData[i].date,
-          cases: window.map(d => d.cases).reduce(sum),
-          sequenced: window.map(d => d.sequenced).reduce(sum),
-          variantCount: window.map(d => d.variantCount).reduce(sum),
+          cases: window.map(d => d.cases).reduce(sum) / 7,
+          sequenced: window.map(d => d.sequenced).reduce(sum) / 7,
+          variantCount: window.map(d => d.variantCount).reduce(sum) / 7,
         });
       }
 
@@ -96,7 +96,7 @@ export const EstimatedCasesChart = React.memo(
         });
       }
       const ticks = getTicks(
-        filteredData.map(d => ({
+        smoothedData.map(d => ({
           date: d.date.dayjs.toDate(),
         }))
       );

--- a/src/helpers/sample-set.ts
+++ b/src/helpers/sample-set.ts
@@ -77,6 +77,15 @@ export class SampleSet<S extends NewSampleSelector | null = NewSampleSelector | 
     return output;
   }
 
+  countByDate(): Map<UnifiedDay, number> {
+    const output = new Map<UnifiedDay, number>();
+    for (const multiSample of this.data) {
+      const oldCount = output.get(multiSample.date) ?? 0;
+      output.set(multiSample.date, oldCount + multiSample.count);
+    }
+    return output;
+  }
+
   groupByField<F extends CountableMultiSampleField>(
     field: F
   ): Map<ParsedMultiSample[F], ParsedMultiSample[]> {

--- a/src/helpers/sequencing-intensity-entry-set.ts
+++ b/src/helpers/sequencing-intensity-entry-set.ts
@@ -1,0 +1,13 @@
+import { SequencingIntensityEntry } from '../services/api-types';
+import * as zod from 'zod';
+import { NewSampleSelector } from './sample-selector';
+
+export const SequencingIntensityEntrySetSelectorSchema = zod.object({
+  country: zod.string().optional(),
+});
+
+export type SequencingIntensityEntrySet = { data: SequencingIntensityEntry[] };
+export type SequencingIntensityEntrySetSelector = zod.infer<typeof SequencingIntensityEntrySetSelectorSchema>;
+export type SequencingIntensityEntrySetWithSelector = SequencingIntensityEntrySet & {
+  readonly selector: NewSampleSelector;
+};

--- a/src/helpers/ticks.ts
+++ b/src/helpers/ticks.ts
@@ -1,0 +1,22 @@
+/**
+ * A very basic function that returns three ticks: the first date, the last date, and the date that lies in the middle.
+ *
+ * @param data: A list that is sorted by date ascendantly
+ */
+export function getTicks(data: { date: Date }[]): number[] {
+  let ticksDates: Date[] = [];
+  if (data.length === 0) {
+    ticksDates = [];
+  } else if (data.length === 1) {
+    ticksDates = [data[0].date];
+  } else {
+    const startDate = data[0].date;
+    const endDate = data[data.length - 1].date;
+    if (data.length === 2) {
+      ticksDates = [startDate, endDate];
+    } else {
+      ticksDates = [startDate, new Date((endDate.getTime() + startDate.getTime()) / 2), endDate];
+    }
+  }
+  return ticksDates.map(d => d.getTime());
+}

--- a/src/models/wasteWater/WasteWaterSummaryTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterSummaryTimeChart.tsx
@@ -4,7 +4,8 @@ import { schemeCategory10 } from 'd3-scale-chromatic';
 import { ChartAndMetricsWrapper, ChartWrapper, TitleWrapper, Wrapper } from '../../charts/common';
 import { ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { WasteWaterTimeseriesSummaryDataset } from './types';
-import { formatDate, getTicks } from './WasteWaterTimeChart';
+import { formatDate } from './WasteWaterTimeChart';
+import { getTicks } from '../../helpers/ticks';
 
 interface Props {
   wasteWaterPlants: {

--- a/src/models/wasteWater/WasteWaterTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterTimeChart.tsx
@@ -3,29 +3,7 @@ import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } f
 import Metric, { MetricsSpacing, MetricsWrapper } from '../../charts/Metrics';
 import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { WasteWaterTimeEntry, WasteWaterTimeseriesSummaryDataset } from './types';
-
-/**
- * A very basic function that returns three ticks: the first date, the last date, and the date that lies in the middle.
- *
- * @param data: A list that is sorted by date ascendantly
- */
-export function getTicks(data: { date: Date }[]): number[] {
-  let ticksDates: Date[] = [];
-  if (data.length === 0) {
-    ticksDates = [];
-  } else if (data.length === 1) {
-    ticksDates = [data[0].date];
-  } else {
-    const startDate = data[0].date;
-    const endDate = data[data.length - 1].date;
-    if (data.length === 2) {
-      ticksDates = [startDate, endDate];
-    } else {
-      ticksDates = [startDate, new Date((endDate.getTime() + startDate.getTime()) / 2), endDate];
-    }
-  }
-  return ticksDates.map(d => d.getTime());
-}
+import { getTicks } from '../../helpers/ticks';
 
 export function formatDate(date: number) {
   const d = new Date(date);

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -21,9 +21,7 @@ import {
 } from '../services/api';
 import { Country } from '../services/api-types';
 import dayjs from 'dayjs';
-import {
-  SequencingIntensityEntrySetWithSelector,
-} from '../helpers/sequencing-intensity-entry-set';
+import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
 
 // a promise which is never resolved or rejected
 const waitForever = new Promise<never>(() => {});
@@ -139,7 +137,7 @@ export const ExploreFocusSplit = () => {
   ) {
     explorePage = <Loader />;
   } else if (sequencingIntensityEntrySetState.status === 'rejected') {
-    return <Alert variant='danger'>Failed to load data</Alert>;
+    explorePage = <Alert variant='danger'>Failed to load data</Alert>;
   } else {
     explorePage = (
       <ExploreWrapper>
@@ -182,12 +180,18 @@ export const ExploreFocusSplit = () => {
     variantSampleSetState.status === 'initial' ||
     variantSampleSetState.status === 'pending' ||
     wholeSampleSetState.status === 'initial' ||
-    wholeSampleSetState.status === 'pending'
+    wholeSampleSetState.status === 'pending' ||
+    sequencingIntensityEntrySetState.status === 'initial' ||
+    sequencingIntensityEntrySetState.status === 'pending'
   ) {
     return makeLayout(<Loader />, <Loader />);
   }
 
-  if (variantSampleSetState.status === 'rejected' || wholeSampleSetState.status === 'rejected') {
+  if (
+    variantSampleSetState.status === 'rejected' ||
+    wholeSampleSetState.status === 'rejected' ||
+    sequencingIntensityEntrySetState.status === 'rejected'
+  ) {
     const alert = <Alert variant='danger'>Failed to load samples</Alert>;
     return makeLayout(alert, alert);
   }
@@ -204,6 +208,7 @@ export const ExploreFocusSplit = () => {
         wholeSampleSet={wholeSampleSetState.data}
         variantInternationalSampleSetState={variantInternationalSampleSetState}
         wholeInternationalSampleSetState={wholeInternationalSampleSetState}
+        sequencingIntensityEntrySet={sequencingIntensityEntrySetState.data}
       />
     ),
     variantSelector && (

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -13,6 +13,7 @@ import { isRegion } from '../services/api';
 import { SequencingIntensityPlotWidget } from '../widgets/SequencingIntensityPlot';
 import styled from 'styled-components';
 import { ExternalLink } from '../components/ExternalLink';
+import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
 
 interface Props {
   country: Country;
@@ -21,6 +22,7 @@ interface Props {
   onVariantSelect: (selection: VariantSelector) => void;
   selection: VariantSelector | undefined;
   wholeSampleSetState: AsyncState<SampleSetWithSelector>;
+  sequencingIntensityEntrySet: SequencingIntensityEntrySetWithSelector;
 }
 
 const Footer = styled.footer`
@@ -37,6 +39,7 @@ export const ExplorePage = ({
   onVariantSelect,
   selection,
   wholeSampleSetState,
+  sequencingIntensityEntrySet,
 }: Props) => {
   return (
     <ScrollableTabs
@@ -49,7 +52,7 @@ export const ExplorePage = ({
               <NamedSection title=''>
                 <SequencingIntensityPlotWidget.ShareableComponent
                   title='Sequencing Intensity'
-                  country={country}
+                  sequencingIntensityEntrySet={sequencingIntensityEntrySet}
                   height={300}
                   widgetLayout={NamedSection}
                 />

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -23,6 +23,8 @@ import { VariantMutations } from '../components/VariantMutations';
 import WasteWaterSummaryTimeChart from '../models/wasteWater/WasteWaterSummaryTimeChart';
 import { WasteWaterDataset } from '../models/wasteWater/types';
 import { getData } from '../models/wasteWater/loading';
+import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
+import { EstimatedCasesPlotWidget } from '../widgets/EstimatedCasesPlot';
 
 interface Props {
   country: Country;
@@ -34,6 +36,7 @@ interface Props {
   wholeSampleSet: SampleSetWithSelector;
   variantInternationalSampleSetState: AsyncState<SampleSetWithSelector>;
   wholeInternationalSampleSetState: AsyncState<SampleSetWithSelector>;
+  sequencingIntensityEntrySet: SequencingIntensityEntrySetWithSelector;
 }
 
 const deepFocusPaths = {
@@ -48,6 +51,7 @@ export const FocusPage = ({
   wholeSampleSet,
   variantInternationalSampleSetState,
   wholeInternationalSampleSetState,
+  sequencingIntensityEntrySet,
   ...forwardedProps
 }: Props) => {
   const { country, matchPercentage, variant, samplingStrategy, dateRange } = forwardedProps;
@@ -125,6 +129,14 @@ export const FocusPage = ({
             wholeSampleSet={wholeSampleSet}
             height={300}
             title='Sequences over time'
+          />
+        </GridCell>
+        <GridCell minWidth={600}>
+          <EstimatedCasesPlotWidget.ShareableComponent
+            variantSampleSet={variantSampleSet}
+            sequencingIntensityEntrySet={sequencingIntensityEntrySet}
+            height={300}
+            title='Estimated cases'
           />
         </GridCell>
         <GridCell minWidth={600}>

--- a/src/widgets/EstimatedCasesPlot.tsx
+++ b/src/widgets/EstimatedCasesPlot.tsx
@@ -1,0 +1,68 @@
+import { SampleSetWithSelector } from '../helpers/sample-set';
+import {
+  SequencingIntensityEntrySetSelectorSchema,
+  SequencingIntensityEntrySetWithSelector,
+} from '../helpers/sequencing-intensity-entry-set';
+import DownloadWrapper from '../charts/DownloadWrapper';
+import { EstimatedCasesChart, EstimatedCasesTimeEntry } from '../charts/EstimatedCasesChart';
+import { globalDateCache, UnifiedDay } from '../helpers/date-cache';
+import { Widget } from './Widget';
+import { AsyncZodQueryEncoder } from '../helpers/query-encoder';
+import * as zod from 'zod';
+import { NewSampleSelectorSchema } from '../helpers/sample-selector';
+import { getNewSamples, getSequencingIntensity } from '../services/api';
+
+interface Props {
+  variantSampleSet: SampleSetWithSelector;
+  sequencingIntensityEntrySet: SequencingIntensityEntrySetWithSelector;
+}
+
+export const EstimatedCasesPlot = ({ variantSampleSet, sequencingIntensityEntrySet }: Props) => {
+  const data: Map<UnifiedDay, EstimatedCasesTimeEntry> = new Map();
+  for (let entry of sequencingIntensityEntrySet.data) {
+    const date = globalDateCache.getDay(entry.x);
+    data.set(date, {
+      date,
+      cases: entry.y.numberCases,
+      sequenced: entry.y.numberSequenced,
+      variantCount: 0,
+    });
+  }
+  const variantCounts = variantSampleSet.countByDate();
+  for (let [unifiedDay, count] of variantCounts.entries()) {
+    const entry = data.get(unifiedDay);
+    if (!entry) {
+      // TODO This should never happen and indicate an error with the data. Once we have a error reporting system,
+      //   this could be reported?
+      continue;
+    }
+    entry.variantCount = count;
+  }
+  return (
+    <DownloadWrapper name='EstimatedCasesPlot'>
+      <EstimatedCasesChart data={new Array(...data.values())} />
+    </DownloadWrapper>
+  );
+};
+
+export const EstimatedCasesPlotWidget = new Widget(
+  new AsyncZodQueryEncoder(
+    zod.object({
+      variantSampleSelector: NewSampleSelectorSchema,
+      sequencingIntensityEntrySetSelector: SequencingIntensityEntrySetSelectorSchema,
+    }),
+    async (decoded: Props) => ({
+      variantSampleSelector: decoded.variantSampleSet.sampleSelector,
+      sequencingIntensityEntrySetSelector: decoded.sequencingIntensityEntrySet.selector,
+    }),
+    async (encoded, signal) => ({
+      variantSampleSet: await getNewSamples(encoded.variantSampleSelector, signal),
+      sequencingIntensityEntrySet: await getSequencingIntensity(
+        encoded.sequencingIntensityEntrySetSelector,
+        signal
+      ),
+    })
+  ),
+  EstimatedCasesPlot,
+  'EstimatedCasesPlot'
+);

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -5,6 +5,7 @@ import { Chen2021FitnessWidget } from '../models/chen2021Fitness/Chen2021Fitness
 import { SequencingIntensityPlotWidget } from './SequencingIntensityPlot';
 import { WasteWaterTimeWidget } from '../models/wasteWater/WasteWaterTimeWidget';
 import { WasteWaterHeatMapWidget } from '../models/wasteWater/WasteWaterHeatMapWidget';
+import { EstimatedCasesPlotWidget } from './EstimatedCasesPlot';
 
 export const allWidgets = [
   VariantAgeDistributionPlotWidget,
@@ -14,4 +15,5 @@ export const allWidgets = [
   Chen2021FitnessWidget,
   WasteWaterTimeWidget,
   WasteWaterHeatMapWidget,
+  EstimatedCasesPlotWidget,
 ];


### PR DESCRIPTION
As discussed, the sequencing intensity data is now loaded by the ExploreFocusSplit and passed down both to the explore and the focus page. The data is then used by the estimated case numbers plot. One open problem is #126.

Closes #116 

---

A screenshot :)

![image](https://user-images.githubusercontent.com/18666552/117684861-af1c5a80-b1b5-11eb-8417-9ae600a212bd.png)
