### PR TITLE
Improve the positioning of the metrics on small screens

### DIFF
--- a/src/charts/EstimatedCasesChart.tsx
+++ b/src/charts/EstimatedCasesChart.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { UnifiedDay } from '../helpers/date-cache';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from './common';
 import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import Metric, { MetricsSpacing, MetricsWrapper } from './Metrics';
+import Metric, { MetricsWrapper } from './Metrics';
 import { getTicks } from '../helpers/ticks';
 import { calculateWilsonInterval } from '../helpers/wilson-interval';
 import dayjs from 'dayjs';
@@ -191,7 +191,6 @@ export const EstimatedCasesChart = React.memo(
               </ResponsiveContainer>
             </ChartWrapper>
             <MetricsWrapper>
-              <MetricsSpacing />
               <Metric
                 value={active !== undefined ? active.estimatedCases.toFixed(0) : 'NA'}
                 title='Est. cases'

--- a/src/charts/GroupedProportionComparisonChart.tsx
+++ b/src/charts/GroupedProportionComparisonChart.tsx
@@ -13,7 +13,7 @@ import {
 } from 'recharts';
 import styled from 'styled-components';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from './common';
-import Metric, {  MetricsWrapper } from './Metrics';
+import Metric, { MetricsWrapper } from './Metrics';
 import { ScatterLegendItem, ScatterLegend } from './ScatterLegend';
 
 const CHART_MARGIN_BOTTOM = 30;

--- a/src/charts/GroupedProportionComparisonChart.tsx
+++ b/src/charts/GroupedProportionComparisonChart.tsx
@@ -13,7 +13,7 @@ import {
 } from 'recharts';
 import styled from 'styled-components';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from './common';
-import Metric, { MetricsSpacing, MetricsWrapper } from './Metrics';
+import Metric, {  MetricsWrapper } from './Metrics';
 import { ScatterLegendItem, ScatterLegend } from './ScatterLegend';
 
 const CHART_MARGIN_BOTTOM = 30;
@@ -279,7 +279,6 @@ export const GroupedProportionComparisonChart = React.memo(
           <MetricsWrapper>
             {extendedMetrics ? (
               <>
-                <MetricsSpacing />
                 <ExtendedScatterLegendWrapper>
                   <ScatterLegend items={[subjectLegendItem]} />
                 </ExtendedScatterLegendWrapper>
@@ -287,7 +286,6 @@ export const GroupedProportionComparisonChart = React.memo(
             ) : (
               <>
                 <ScatterLegend items={[subjectLegendItem, referenceLegendItem]} />
-                <MetricsSpacing />
               </>
             )}
             <Metric
@@ -305,7 +303,6 @@ export const GroupedProportionComparisonChart = React.memo(
           </MetricsWrapper>
           {extendedMetrics && (
             <MetricsWrapper>
-              <MetricsSpacing />
               <ExtendedScatterLegendWrapper>
                 <ScatterLegend items={[referenceLegendItem]} />
               </ExtendedScatterLegendWrapper>

--- a/src/charts/GroupedProportionComparisonChart.tsx
+++ b/src/charts/GroupedProportionComparisonChart.tsx
@@ -5,14 +5,15 @@ import {
   CartesianGrid,
   ComposedChart,
   ErrorBar,
+  ResponsiveContainer,
   Scatter,
   ScatterProps,
   XAxis,
   YAxis,
 } from 'recharts';
 import styled from 'styled-components';
-import { ChartAndMetricsWrapper, ChartWrapper, colors, Wrapper } from './common';
-import Metric, { MetricsSpacing, MetricsWrapper, METRIC_RIGHT_PADDING_PX, METRIC_WIDTH_PX } from './Metrics';
+import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from './common';
+import Metric, { MetricsSpacing, MetricsWrapper } from './Metrics';
 import { ScatterLegendItem, ScatterLegend } from './ScatterLegend';
 
 const CHART_MARGIN_BOTTOM = 30;
@@ -108,8 +109,6 @@ export type Props = {
   data: GroupValue[];
   total: { subject: SubgroupValue; reference: SubgroupValue };
   texts: TopLevelTexts;
-  width: number;
-  height: number;
   extendedMetrics?: boolean;
   maxY?: number; // percentage formatting is disabled if maxY is used
   hideReferenceScatter?: boolean;
@@ -121,8 +120,6 @@ export const GroupedProportionComparisonChart = React.memo(
     data,
     total,
     texts,
-    width,
-    height,
     extendedMetrics,
     maxY,
     hideReferenceScatter,
@@ -203,81 +200,81 @@ export const GroupedProportionComparisonChart = React.memo(
 
     return (
       <Wrapper>
+        <TitleWrapper>{texts.title}</TitleWrapper>
         <ChartAndMetricsWrapper>
           <ChartWrapper>
-            <ComposedChart
-              width={width - (extendedMetrics ? 2 : 1) * METRIC_WIDTH_PX - METRIC_RIGHT_PADDING_PX}
-              // width="100%"
-              height={height}
-              margin={{ top: 6, right: 0, left: 0, bottom: CHART_MARGIN_BOTTOM }}
-              onMouseLeave={handleMouseLeave}
-              data={hoverBarData}
-              barCategoryGap='0%'
-            >
-              <XAxis
-                dataKey='label'
-                allowDuplicatedCategory={false}
-                axisLine={false}
-                tickLine={false}
-                interval={0}
-                tick={<CustomTick currentValue={currentData?.label} />}
-              />
-              <YAxis
-                dataKey='y'
-                axisLine={false}
-                tickLine={false}
-                domain={
-                  typeof maxY === 'number'
-                    ? [0, maxY]
-                    : [0, (dataMax: number) => Math.min(1, Math.ceil(dataMax * 10) / 10)]
-                }
-                allowDataOverflow={typeof maxY === 'number'}
-                scale='linear'
-                tickFormatter={typeof maxY === 'number' ? undefined : v => `${(v * 100).toFixed(0)}%`}
-              />
-              <CartesianGrid vertical={false} />
-              <Bar {...commonProps} dataKey='y' fill='transparent' />
-              {!hideReferenceScatter && (
+            <ResponsiveContainer>
+              <ComposedChart
+                margin={{ top: 6, right: 0, left: 0, bottom: CHART_MARGIN_BOTTOM }}
+                onMouseLeave={handleMouseLeave}
+                data={hoverBarData}
+                barCategoryGap='0%'
+              >
+                <XAxis
+                  dataKey='label'
+                  allowDuplicatedCategory={false}
+                  axisLine={false}
+                  tickLine={false}
+                  interval={0}
+                  tick={<CustomTick currentValue={currentData?.label} />}
+                />
+                <YAxis
+                  dataKey='y'
+                  axisLine={false}
+                  tickLine={false}
+                  domain={
+                    typeof maxY === 'number'
+                      ? [0, maxY]
+                      : [0, (dataMax: number) => Math.min(1, Math.ceil(dataMax * 10) / 10)]
+                  }
+                  allowDataOverflow={typeof maxY === 'number'}
+                  scale='linear'
+                  tickFormatter={typeof maxY === 'number' ? undefined : v => `${(v * 100).toFixed(0)}%`}
+                />
+                <CartesianGrid vertical={false} />
+                <Bar {...commonProps} dataKey='y' fill='transparent' />
+                {!hideReferenceScatter && (
+                  <Scatter
+                    {...commonProps}
+                    data={makeScatterData('reference', {
+                      active: colors.inactive,
+                      inactive: colors.inactive,
+                    })}
+                    shape={ScatterBarShape}
+                  >
+                    <ErrorBar
+                      direction='y'
+                      dataKey='yErrorActive'
+                      stroke={colors.inactive}
+                      {...referenceErrorBarSizes}
+                    />
+                    <ErrorBar
+                      direction='y'
+                      dataKey='yErrorInactive'
+                      stroke={colors.inactive}
+                      {...referenceErrorBarSizes}
+                    />
+                  </Scatter>
+                )}
                 <Scatter
                   {...commonProps}
-                  data={makeScatterData('reference', {
-                    active: colors.inactive,
-                    inactive: colors.inactive,
-                  })}
-                  shape={ScatterBarShape}
+                  data={makeScatterData('subject', { active: colors.active, inactive: colors.inactive })}
                 >
                   <ErrorBar
                     direction='y'
                     dataKey='yErrorActive'
-                    stroke={colors.inactive}
-                    {...referenceErrorBarSizes}
+                    stroke={colors.active}
+                    {...subjectErrorBarSizes}
                   />
                   <ErrorBar
                     direction='y'
                     dataKey='yErrorInactive'
                     stroke={colors.inactive}
-                    {...referenceErrorBarSizes}
+                    {...subjectErrorBarSizes}
                   />
                 </Scatter>
-              )}
-              <Scatter
-                {...commonProps}
-                data={makeScatterData('subject', { active: colors.active, inactive: colors.inactive })}
-              >
-                <ErrorBar
-                  direction='y'
-                  dataKey='yErrorActive'
-                  stroke={colors.active}
-                  {...subjectErrorBarSizes}
-                />
-                <ErrorBar
-                  direction='y'
-                  dataKey='yErrorInactive'
-                  stroke={colors.inactive}
-                  {...subjectErrorBarSizes}
-                />
-              </Scatter>
-            </ComposedChart>
+              </ComposedChart>
+            </ResponsiveContainer>
           </ChartWrapper>
           <MetricsWrapper>
             {extendedMetrics ? (

--- a/src/charts/Metrics.tsx
+++ b/src/charts/Metrics.tsx
@@ -7,22 +7,22 @@ export const METRIC_RIGHT_PADDING_PX = 16;
 export const METRIC_WIDTH_PX = 160;
 const TOOLTIP_DALAY = 500;
 
-// export const MetricsWrapper = styled.div`
-//   padding: 0.6rem 0 0 0;
-//   flex-grow: 1;
-//   display: flex;
-//   flex-direction: row;
-//   justify-content: space-between;
-
-//   @media (min-width: 640px) {
-//     flex-direction: column;
-//     padding: 0 0 1.8rem 0rem;
-//   }
-// `;
-
-export const MetricsWrapper = ({ id, children, className }: { id?: string; children: React.ReactNode, className?: string}) => {
+export const MetricsWrapper = ({
+  id,
+  children,
+  className,
+}: {
+  id?: string;
+  children: React.ReactNode;
+  className?: string;
+}) => {
   return (
-    <div id={id} className={`pl-1 flex-grow flex flex-row sm:flex-col sm:pb-8 ${className ? className : ""}`}>
+    <div
+      id={id}
+      className={`pl-2 pt-1 flex-grow flex flex-row sm:flex-col sm:pt-0 sm:pl-1 sm:pb-8 ${
+        className ? className : ''
+      }`}
+    >
       {children}
     </div>
   );
@@ -67,7 +67,7 @@ export const ValueWrapper = ({
 
 export const MetricWrapper = ({ id, children }: { id: string; children: React.ReactNode }) => {
   return (
-    <div id={id} className='ml-2 sm:pl-0 flex flex-col justify-end h-full flex-grow w-28 pr-1 md:w-40'>
+    <div id={id} className='flex flex-col justify-end h-full flex-grow w-28 pr-1 md:w-40'>
       {children}
     </div>
   );

--- a/src/charts/Metrics.tsx
+++ b/src/charts/Metrics.tsx
@@ -20,11 +20,6 @@ export const MetricsWrapper = styled.div`
   }
 `;
 
-export const MetricsSpacing = styled.div`
-  display: flex;
-  flex-grow: 1;
-`;
-
 export const colors = {
   active: '#2980b9',
   inactive: '#bdc3c7',

--- a/src/charts/Metrics.tsx
+++ b/src/charts/Metrics.tsx
@@ -8,11 +8,16 @@ export const METRIC_WIDTH_PX = 160;
 const TOOLTIP_DALAY = 500;
 
 export const MetricsWrapper = styled.div`
-  padding: 0 0 1.8rem 0rem;
+  padding: 0.6rem 0 0 0;
   flex-grow: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: space-between;
+
+  @media (min-width: 640px) {
+    flex-direction: column;
+    padding: 0 0 1.8rem 0rem;
+  }
 `;
 
 export const MetricsSpacing = styled.div`

--- a/src/charts/Metrics.tsx
+++ b/src/charts/Metrics.tsx
@@ -7,18 +7,26 @@ export const METRIC_RIGHT_PADDING_PX = 16;
 export const METRIC_WIDTH_PX = 160;
 const TOOLTIP_DALAY = 500;
 
-export const MetricsWrapper = styled.div`
-  padding: 0.6rem 0 0 0;
-  flex-grow: 1;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+// export const MetricsWrapper = styled.div`
+//   padding: 0.6rem 0 0 0;
+//   flex-grow: 1;
+//   display: flex;
+//   flex-direction: row;
+//   justify-content: space-between;
 
-  @media (min-width: 640px) {
-    flex-direction: column;
-    padding: 0 0 1.8rem 0rem;
-  }
-`;
+//   @media (min-width: 640px) {
+//     flex-direction: column;
+//     padding: 0 0 1.8rem 0rem;
+//   }
+// `;
+
+export const MetricsWrapper = ({ id, children, className }: { id?: string; children: React.ReactNode, className?: string}) => {
+  return (
+    <div id={id} className={`pl-1 flex-grow flex flex-row sm:flex-col sm:pb-8 ${className ? className : ""}`}>
+      {children}
+    </div>
+  );
+};
 
 export const colors = {
   active: '#2980b9',
@@ -59,7 +67,7 @@ export const ValueWrapper = ({
 
 export const MetricWrapper = ({ id, children }: { id: string; children: React.ReactNode }) => {
   return (
-    <div id={id} className='flex flex-col justify-end h-full flex-grow w-28 pr-1 md:w-40'>
+    <div id={id} className='ml-2 sm:pl-0 flex flex-col justify-end h-full flex-grow w-28 pr-1 md:w-40'>
       {children}
     </div>
   );

--- a/src/charts/TimeChart.tsx
+++ b/src/charts/TimeChart.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import Metric, { MetricsWrapper, MetricsSpacing } from './Metrics';
+import Metric, { MetricsWrapper } from './Metrics';
 import { BarChart, XAxis, YAxis, Bar, Cell, ResponsiveContainer, CartesianGrid } from 'recharts';
 import {
   colors,
@@ -127,7 +127,6 @@ export const TimeChart = React.memo(
             </ResponsiveContainer>
           </ChartWrapper>
           <MetricsWrapper>
-            <MetricsSpacing />
             <Metric
               value={currentData.percent === undefined ? '-' : currentData.percent.toFixed(2)}
               title='Proportion'

--- a/src/charts/TimeIntensityChart.tsx
+++ b/src/charts/TimeIntensityChart.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import Metric, { MetricsWrapper, MetricsSpacing } from './Metrics';
+import Metric, { MetricsWrapper } from './Metrics';
 import { BarChart, XAxis, YAxis, Bar, Cell, ResponsiveContainer, CartesianGrid } from 'recharts';
 import {
   colors,
@@ -132,7 +132,6 @@ export const TimeIntensityChart = React.memo(
             </ResponsiveContainer>
           </ChartWrapper>
           <MetricsWrapper>
-            <MetricsSpacing />
             <Metric
               value={kFormat(currentData.quantity)}
               title='Confirmed'

--- a/src/charts/TypeDistributionChart.tsx
+++ b/src/charts/TypeDistributionChart.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import Metric, { MetricsWrapper, MetricsSpacing } from './Metrics';
+import Metric, { MetricsWrapper } from './Metrics';
 import { BarChart, XAxis, YAxis, Bar, Cell, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { colors, Wrapper, TitleWrapper, ChartAndMetricsWrapper, ChartWrapper } from './common';
 
@@ -144,7 +144,6 @@ export const TypeDistributionChart = React.memo(
             </ResponsiveContainer>
           </ChartWrapper>
           <MetricsWrapper>
-            <MetricsSpacing />
             <Metric
               value={currentData.percent === undefined ? '-' : currentData.percent.toFixed(2)}
               title='Proportion'

--- a/src/charts/common.tsx
+++ b/src/charts/common.tsx
@@ -36,11 +36,16 @@ export const TitleWrapper = ({ children, id }: { children: React.ReactNode; id?:
 
 export const ChartAndMetricsWrapper = styled.div`
   display: flex;
+  flex-direction: column;
   flex: 1;
+
+  @media (min-width: 640px) {
+    flex-direction: row;
+  }
 `;
 
 export const ChartWrapper = styled.div`
-  flex-grow: 0;
+  flex-grow: 1;
   width: 100%;
 `;
 

--- a/src/models/chen2021Fitness/Chen2021FitnessPreview.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessPreview.tsx
@@ -5,7 +5,7 @@ import { OldSampleSelectorSchema } from '../../helpers/sample-selector';
 import { Chen2021ProportionPlot } from './Chen2021ProportionPlot';
 import { fillRequestWithDefaults, useModelData } from './loading';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, Wrapper } from '../../charts/common';
-import Metric, { MetricsSpacing, MetricsWrapper } from '../../charts/Metrics';
+import Metric, {  MetricsWrapper } from '../../charts/Metrics';
 
 type Props = zod.infer<typeof OldSampleSelectorSchema>;
 
@@ -43,7 +43,6 @@ export const Chen2021FitnessPreview = ({
           />
         </ChartWrapper>
         <MetricsWrapper>
-          <MetricsSpacing />
           <Metric
             value={(modelData.params.fd.value * 100).toFixed(0)}
             title={'Current adv.'}

--- a/src/models/chen2021Fitness/Chen2021FitnessPreview.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessPreview.tsx
@@ -5,7 +5,7 @@ import { OldSampleSelectorSchema } from '../../helpers/sample-selector';
 import { Chen2021ProportionPlot } from './Chen2021ProportionPlot';
 import { fillRequestWithDefaults, useModelData } from './loading';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, Wrapper } from '../../charts/common';
-import Metric, {  MetricsWrapper } from '../../charts/Metrics';
+import Metric, { MetricsWrapper } from '../../charts/Metrics';
 
 type Props = zod.infer<typeof OldSampleSelectorSchema>;
 

--- a/src/models/wasteWater/WasteWaterHeatMapChart.tsx
+++ b/src/models/wasteWater/WasteWaterHeatMapChart.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { scaleLinear } from 'd3-scale';
 import styled from 'styled-components';
-import Metric, {  MetricsWrapper } from '../../charts/Metrics';
+import Metric, { MetricsWrapper } from '../../charts/Metrics';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from '../../charts/common';
 import { WasteWaterHeatMapEntry, WasteWaterMutationOccurrencesDataset } from './types';
 import { UnifiedDay } from '../../helpers/date-cache';

--- a/src/models/wasteWater/WasteWaterHeatMapChart.tsx
+++ b/src/models/wasteWater/WasteWaterHeatMapChart.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { scaleLinear } from 'd3-scale';
 import styled from 'styled-components';
-import Metric, { MetricsSpacing, MetricsWrapper } from '../../charts/Metrics';
+import Metric, {  MetricsWrapper } from '../../charts/Metrics';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from '../../charts/common';
 import { WasteWaterHeatMapEntry, WasteWaterMutationOccurrencesDataset } from './types';
 import { UnifiedDay } from '../../helpers/date-cache';
@@ -158,7 +158,6 @@ export const WasteWaterHeatMapChart = React.memo(
             </div>
           </ChartWrapper2>
           <MetricsWrapper>
-            <MetricsSpacing />
             <Metric
               value={active?.proportion !== undefined ? (active.proportion * 100).toFixed(2) + '%' : 'NA'}
               title='Proportion'

--- a/src/models/wasteWater/WasteWaterTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterTimeChart.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from '../../charts/common';
-import Metric, { MetricsSpacing, MetricsWrapper } from '../../charts/Metrics';
+import Metric, { MetricsWrapper } from '../../charts/Metrics';
 import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { WasteWaterTimeEntry, WasteWaterTimeseriesSummaryDataset } from './types';
 import { getTicks } from '../../helpers/ticks';
@@ -91,7 +91,6 @@ export const WasteWaterTimeChart = React.memo(
             </ResponsiveContainer>
           </ChartWrapper>
           <MetricsWrapper>
-            <MetricsSpacing />
             <Metric
               value={active !== undefined ? (active.proportion * 100).toFixed(2) + '%' : 'NA'}
               title='Proportion'

--- a/src/widgets/HospitalizationDeathPlot.tsx
+++ b/src/widgets/HospitalizationDeathPlot.tsx
@@ -4,7 +4,6 @@ import { capitalize, omit } from 'lodash';
 import React, { useMemo } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 import * as zod from 'zod';
-import { TitleWrapper } from '../charts/common';
 import DownloadWrapper from '../charts/DownloadWrapper';
 import {
   GroupedProportionComparisonChart,
@@ -219,16 +218,13 @@ export const HospitalizationDeathPlot = ({
 
   return (
     <DownloadWrapper name='HospitalizationDeathPlot' csvData={csvData}>
-      <div ref={ref as React.MutableRefObject<HTMLDivElement>} style={{ height: '300px' }}>
+      <div ref={ref as React.MutableRefObject<HTMLDivElement>} className='h-full'>
         {width && height && (
           <>
-            <TitleWrapper>{texts.title}</TitleWrapper>
             <GroupedProportionComparisonChart
               data={processedData}
               total={total}
               texts={texts}
-              width={width}
-              height={height}
               extendedMetrics={extendedMetrics}
               onClickHandler={noopOnClickHandler}
               maxY={

--- a/src/widgets/MetadataAvailabilityPlot.tsx
+++ b/src/widgets/MetadataAvailabilityPlot.tsx
@@ -9,7 +9,7 @@ import { getSequenceCounts } from '../services/api';
 import { Attribute, attributes } from './SequencingRepresentativenessPlot';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from '../charts/common';
 import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import Metrics, { MetricsSpacing, MetricsWrapper } from '../charts/Metrics';
+import Metrics, { MetricsWrapper } from '../charts/Metrics';
 import { kFormat } from '../helpers/number';
 import Loader from '../components/Loader';
 
@@ -103,7 +103,6 @@ export const MetadataAvailabilityPlot = ({ selector }: Props) => {
           </ResponsiveContainer>
         </ChartWrapper>
         <MetricsWrapper>
-          <MetricsSpacing />
           <Metrics
             value={active ? kFormat(active.known) : '-'}
             title={'Available'}


### PR DESCRIPTION
The metrics are now below the plots on small screens:

![image](https://user-images.githubusercontent.com/18666552/120775184-42ca1800-c523-11eb-903f-a5ab279bc094.png)

I removed the `width` and `height` parameters in `GroupedProportionComparisonChart` to increase responsiveness and don't understand why they were used instead of the `ResponsiveContainer` in the first place. @TKGZ, do you see a problem?