### PR TITLE
Feature/sequencing and metadata coverage

### DIFF
--- a/src/components/SequencingCoverageDeepExplore.tsx
+++ b/src/components/SequencingCoverageDeepExplore.tsx
@@ -3,6 +3,7 @@ import { SequencingRepresentativenessPlotWidget } from '../widgets/SequencingRep
 import { Country } from '../services/api-types';
 import { DateRange, dateRangeToDates } from '../services/api';
 import dayjs from 'dayjs';
+import { Alert, AlertVariant } from '../helpers/ui';
 
 interface Props {
   country: Country;
@@ -12,14 +13,23 @@ interface Props {
 export const SequencingCoverageDeepExplore = React.memo(({ country, dateRange }: Props) => {
   let { dateFrom, dateTo } = dateRangeToDates(dateRange);
   return (
-    <SequencingRepresentativenessPlotWidget.ShareableComponent
-      title='Sequencing Intensity by Attribute'
-      selector={{
-        country,
-        dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
-        dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
-      }}
-      height={500}
-    />
+    <>
+      {country !== 'Switzerland' && (
+        <Alert variant={AlertVariant.WARNING}>
+          Currently, detailed sequencing coverage data are only available for Switzerland.
+        </Alert>
+      )}
+      {country === 'Switzerland' && (
+        <SequencingRepresentativenessPlotWidget.ShareableComponent
+          title='Sequencing Intensity by Attribute'
+          selector={{
+            country,
+            dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
+            dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
+          }}
+          height={500}
+        />
+      )}
+    </>
   );
 });

--- a/src/components/SequencingCoverageDeepExplore.tsx
+++ b/src/components/SequencingCoverageDeepExplore.tsx
@@ -7,6 +7,7 @@ import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-i
 import { SequencingIntensityPlotWidget } from '../widgets/SequencingIntensityPlot';
 import { NamedCard } from './NamedCard';
 import { GridCell, PackedGrid } from './PackedGrid';
+import { MetadataAvailabilityPlotWidget } from '../widgets/MetadataAvailabilityPlot';
 
 interface Props {
   country: Country;
@@ -26,6 +27,18 @@ export const SequencingCoverageDeepExplore = React.memo(
             sequencingIntensityEntrySet={sequencingIntensityEntrySet}
             height={300}
             widgetLayout={NamedCard}
+          />
+        </GridCell>
+        <GridCell minWidth={600}>
+          <MetadataAvailabilityPlotWidget.ShareableComponent
+            title='Metadata Availability'
+            selector={{
+              country,
+              dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
+              dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
+              samplingStrategy: toLiteralSamplingStrategy(samplingStrategy),
+            }}
+            height={300}
           />
         </GridCell>
         {country === 'Switzerland' && (

--- a/src/components/SequencingCoverageDeepExplore.tsx
+++ b/src/components/SequencingCoverageDeepExplore.tsx
@@ -3,33 +3,44 @@ import { SequencingRepresentativenessPlotWidget } from '../widgets/SequencingRep
 import { Country } from '../services/api-types';
 import { DateRange, dateRangeToDates } from '../services/api';
 import dayjs from 'dayjs';
-import { Alert, AlertVariant } from '../helpers/ui';
+import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
+import { SequencingIntensityPlotWidget } from '../widgets/SequencingIntensityPlot';
+import { NamedCard } from './NamedCard';
+import { GridCell, PackedGrid } from './PackedGrid';
 
 interface Props {
   country: Country;
   dateRange: DateRange;
+  sequencingIntensityEntrySet: SequencingIntensityEntrySetWithSelector;
 }
 
-export const SequencingCoverageDeepExplore = React.memo(({ country, dateRange }: Props) => {
-  let { dateFrom, dateTo } = dateRangeToDates(dateRange);
-  return (
-    <>
-      {country !== 'Switzerland' && (
-        <Alert variant={AlertVariant.WARNING}>
-          Currently, detailed sequencing coverage data are only available for Switzerland.
-        </Alert>
-      )}
-      {country === 'Switzerland' && (
-        <SequencingRepresentativenessPlotWidget.ShareableComponent
-          title='Sequencing Intensity by Attribute'
-          selector={{
-            country,
-            dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
-            dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
-          }}
-          height={500}
-        />
-      )}
-    </>
-  );
-});
+export const SequencingCoverageDeepExplore = React.memo(
+  ({ country, dateRange, sequencingIntensityEntrySet }: Props) => {
+    let { dateFrom, dateTo } = dateRangeToDates(dateRange);
+    return (
+      <PackedGrid maxColumns={2}>
+        <GridCell minWidth={600}>
+          <SequencingIntensityPlotWidget.ShareableComponent
+            title='Sequencing Intensity Over Time'
+            sequencingIntensityEntrySet={sequencingIntensityEntrySet}
+            height={300}
+            widgetLayout={NamedCard}
+          />
+        </GridCell>
+        {country === 'Switzerland' && (
+          <GridCell minWidth={1600}>
+            <SequencingRepresentativenessPlotWidget.ShareableComponent
+              title='Sequencing Intensity by Attribute'
+              selector={{
+                country,
+                dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
+                dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
+              }}
+              height={500}
+            />
+          </GridCell>
+        )}
+      </PackedGrid>
+    );
+  }
+);

--- a/src/components/SequencingCoverageDeepExplore.tsx
+++ b/src/components/SequencingCoverageDeepExplore.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SequencingRepresentativenessPlotWidget } from '../widgets/SequencingRepresentativenessPlot';
 import { Country } from '../services/api-types';
-import { DateRange, dateRangeToDates } from '../services/api';
+import { DateRange, dateRangeToDates, SamplingStrategy, toLiteralSamplingStrategy } from '../services/api';
 import dayjs from 'dayjs';
 import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
 import { SequencingIntensityPlotWidget } from '../widgets/SequencingIntensityPlot';
@@ -11,11 +11,12 @@ import { GridCell, PackedGrid } from './PackedGrid';
 interface Props {
   country: Country;
   dateRange: DateRange;
+  samplingStrategy: SamplingStrategy;
   sequencingIntensityEntrySet: SequencingIntensityEntrySetWithSelector;
 }
 
 export const SequencingCoverageDeepExplore = React.memo(
-  ({ country, dateRange, sequencingIntensityEntrySet }: Props) => {
+  ({ country, dateRange, samplingStrategy, sequencingIntensityEntrySet }: Props) => {
     let { dateFrom, dateTo } = dateRangeToDates(dateRange);
     return (
       <PackedGrid maxColumns={2}>
@@ -35,6 +36,7 @@ export const SequencingCoverageDeepExplore = React.memo(
                 country,
                 dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
                 dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
+                samplingStrategy: toLiteralSamplingStrategy(samplingStrategy),
               }}
               height={500}
             />

--- a/src/components/SequencingCoverageDeepExplore.tsx
+++ b/src/components/SequencingCoverageDeepExplore.tsx
@@ -13,12 +13,13 @@ export const SequencingCoverageDeepExplore = React.memo(({ country, dateRange }:
   let { dateFrom, dateTo } = dateRangeToDates(dateRange);
   return (
     <SequencingRepresentativenessPlotWidget.ShareableComponent
-      title='Representativeness of Samples'
+      title='Sequencing Intensity by Attribute'
       selector={{
         country,
         dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
         dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
       }}
+      height={500}
     />
   );
 });

--- a/src/components/SequencingCoverageDeepExplore.tsx
+++ b/src/components/SequencingCoverageDeepExplore.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { SequencingRepresentativenessPlotWidget } from '../widgets/SequencingRepresentativenessPlot';
+import { Country } from '../services/api-types';
+import { DateRange, dateRangeToDates } from '../services/api';
+import dayjs from 'dayjs';
+
+interface Props {
+  country: Country;
+  dateRange: DateRange;
+}
+
+export const SequencingCoverageDeepExplore = React.memo(({ country, dateRange }: Props) => {
+  let { dateFrom, dateTo } = dateRangeToDates(dateRange);
+  return (
+    <SequencingRepresentativenessPlotWidget.ShareableComponent
+      title='Representativeness of Samples'
+      selector={{
+        country,
+        dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
+        dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
+      }}
+    />
+  );
+});

--- a/src/helpers/deep-page.tsx
+++ b/src/helpers/deep-page.tsx
@@ -1,0 +1,48 @@
+/**
+ * This file contains helper functions that are shared by the DeepExplorePage
+ * and the DeepFocusPage.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { scrollableContainerPaddingPx, scrollableContainerStyle } from './scrollable-container';
+import { Route, Switch } from 'react-router';
+
+export interface DeepRoute<Props> {
+  key: string;
+  title: string;
+  content: (props: Props) => JSX.Element;
+}
+
+const HeaderWrapper = styled.div`
+  padding: ${scrollableContainerPaddingPx}px;
+  border-bottom: 1px solid #dee2e6;
+  background: var(--light);
+`;
+
+const ContentWrapper = styled.div`
+  ${scrollableContainerStyle};
+  height: 100px;
+  flex-grow: 1;
+`;
+
+export function makeLayout(header: JSX.Element, content: JSX.Element) {
+  return (
+    <div className='flex flex-col h-full bg-white'>
+      <HeaderWrapper>{header}</HeaderWrapper>
+      <ContentWrapper>{content}</ContentWrapper>
+    </div>
+  );
+}
+
+export function makeSwitch<Props>(routes: DeepRoute<Props>[], props: Props, pathPrefix: string) {
+  return (
+    <Switch>
+      {routes.map(route => (
+        <Route key={route.key} path={`${pathPrefix}/${route.key}`}>
+          {route.content(props)}
+        </Route>
+      ))}
+    </Switch>
+  );
+}

--- a/src/helpers/ui.tsx
+++ b/src/helpers/ui.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Dropdown } from 'react-bootstrap';
+import { useHistory } from 'react-router-dom';
+import { Location } from 'history';
 
 export enum AlertVariant {
   DANGER = 'danger',
@@ -104,5 +106,20 @@ export const DropdownButton = ({ onToggle, className, children, ...restProps }: 
       </Dropdown.Toggle>
       <Dropdown.Menu>{children}</Dropdown.Menu>
     </Dropdown>
+  );
+};
+
+export const ShowMoreButton = ({ to }: { to: Location }) => {
+  const history = useHistory();
+  return (
+    <Button
+      className='mt-1 ml-2'
+      variant={ButtonVariant.PRIMARY}
+      onClick={() => {
+        history.push(to);
+      }}
+    >
+      Show more
+    </Button>
   );
 };

--- a/src/pages/DeepExplorePage.tsx
+++ b/src/pages/DeepExplorePage.tsx
@@ -6,18 +6,26 @@ import { Link } from 'react-router-dom';
 import React from 'react';
 import { Route, useRouteMatch } from 'react-router';
 import { SequencingCoverageDeepExplore } from '../components/SequencingCoverageDeepExplore';
+import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
 
 interface Props {
   country: Country;
   dateRange: DateRange;
   samplingStrategy: SamplingStrategy;
+  sequencingIntensityEntrySet: SequencingIntensityEntrySetWithSelector;
 }
 
 const routes: DeepRoute<Props>[] = [
   {
     key: 'sequencing-coverage',
     title: 'Sequencing Coverage',
-    content: props => <SequencingCoverageDeepExplore country={props.country} dateRange={props.dateRange} />,
+    content: props => (
+      <SequencingCoverageDeepExplore
+        country={props.country}
+        dateRange={props.dateRange}
+        sequencingIntensityEntrySet={props.sequencingIntensityEntrySet}
+      />
+    ),
   },
 ];
 

--- a/src/pages/DeepExplorePage.tsx
+++ b/src/pages/DeepExplorePage.tsx
@@ -4,7 +4,8 @@ import { DeepRoute, makeLayout, makeSwitch } from '../helpers/deep-page';
 import { Button } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import React from 'react';
-import { useRouteMatch } from 'react-router';
+import { Route, useRouteMatch } from 'react-router';
+import { SequencingCoverageDeepExplore } from '../components/SequencingCoverageDeepExplore';
 
 interface Props {
   country: Country;
@@ -12,15 +13,34 @@ interface Props {
   samplingStrategy: SamplingStrategy;
 }
 
-const routes: DeepRoute<Props>[] = [];
+const routes: DeepRoute<Props>[] = [
+  {
+    key: 'sequencing-coverage',
+    title: 'Sequencing Coverage',
+    content: props => <SequencingCoverageDeepExplore country={props.country} dateRange={props.dateRange} />,
+  },
+];
 
 export const DeepExplorePage = (props: Props) => {
   const { path, url } = useRouteMatch();
   const _makeLayout = (content: JSX.Element) =>
     makeLayout(
-      <Button className='mt-2' variant='secondary' as={Link} to={url}>
-        Back to overview
-      </Button>,
+      <div className='ml-3'>
+        <div className='flex'>
+          <h1 style={{ flexGrow: 1 }}>
+            {routes.map(route => (
+              <Route key={route.key} path={`${path}/${route.key}`}>
+                {route.title}
+              </Route>
+            ))}
+          </h1>
+          <div>
+            <Button className='mt-2' variant='secondary' as={Link} to={url}>
+              Back to overview
+            </Button>
+          </div>
+        </div>
+      </div>,
       content
     );
   return _makeLayout(makeSwitch(routes, props, path));

--- a/src/pages/DeepExplorePage.tsx
+++ b/src/pages/DeepExplorePage.tsx
@@ -23,6 +23,7 @@ const routes: DeepRoute<Props>[] = [
       <SequencingCoverageDeepExplore
         country={props.country}
         dateRange={props.dateRange}
+        samplingStrategy={props.samplingStrategy}
         sequencingIntensityEntrySet={props.sequencingIntensityEntrySet}
       />
     ),

--- a/src/pages/DeepExplorePage.tsx
+++ b/src/pages/DeepExplorePage.tsx
@@ -1,0 +1,27 @@
+import { Country } from '../services/api-types';
+import { DateRange, SamplingStrategy } from '../services/api';
+import { DeepRoute, makeLayout, makeSwitch } from '../helpers/deep-page';
+import { Button } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import React from 'react';
+import { useRouteMatch } from 'react-router';
+
+interface Props {
+  country: Country;
+  dateRange: DateRange;
+  samplingStrategy: SamplingStrategy;
+}
+
+const routes: DeepRoute<Props>[] = [];
+
+export const DeepExplorePage = (props: Props) => {
+  const { path, url } = useRouteMatch();
+  const _makeLayout = (content: JSX.Element) =>
+    makeLayout(
+      <Button className='mt-2' variant='secondary' as={Link} to={url}>
+        Back to overview
+      </Button>,
+      content
+    );
+  return _makeLayout(makeSwitch(routes, props, path));
+};

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -30,6 +30,7 @@ import { Country } from '../services/api-types';
 import dayjs from 'dayjs';
 import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
 import { Alert, AlertVariant } from '../helpers/ui';
+import { DeepExplorePage } from './DeepExplorePage';
 
 // a promise which is never resolved or rejected
 const waitForever = new Promise<never>(() => {});
@@ -193,6 +194,10 @@ export const ExploreFocusSplit = ({ isSmallScreen }: Props) => {
     );
   }
 
+  const deepExplorePage = (
+    <DeepExplorePage country={country} dateRange={dateRange} samplingStrategy={samplingStrategy} />
+  );
+
   const makeLayout = (focusContent: React.ReactNode, deepFocusContent: React.ReactNode): JSX.Element => (
     <>
       <Modal show={dataOutdated} backdrop='static' keyboard={false}>
@@ -230,6 +235,9 @@ export const ExploreFocusSplit = ({ isSmallScreen }: Props) => {
         </Route>
         <Route path={`${path}/variants/:variantSelector`}>
           <RawFullContentWrapper>{deepFocusContent}</RawFullContentWrapper>
+        </Route>
+        <Route path={`${path}`}>
+          <RawFullContentWrapper>{deepExplorePage}</RawFullContentWrapper>
         </Route>
       </Switch>
     </>

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -184,6 +184,7 @@ export const ExploreFocusSplit = ({ isSmallScreen }: Props) => {
       <ExplorePage
         country={country}
         samplingStrategy={samplingStrategy}
+        dateRange={dateRange}
         onVariantSelect={variantSelector =>
           history.push(getFocusPageLink({ variantSelector, country, samplingStrategy, dateRange }))
         }

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -172,13 +172,16 @@ export const ExploreFocusSplit = ({ isSmallScreen }: Props) => {
   }
 
   let explorePage: React.ReactNode;
+  let deepExplorePage: React.ReactNode;
   if (
     sequencingIntensityEntrySetState.status === 'initial' ||
     sequencingIntensityEntrySetState.status === 'pending'
   ) {
     explorePage = <Loader />;
+    deepExplorePage = <Loader />;
   } else if (sequencingIntensityEntrySetState.status === 'rejected') {
     explorePage = <Alert variant={AlertVariant.DANGER}>Failed to load data</Alert>;
+    deepExplorePage = <Alert variant={AlertVariant.DANGER}>Failed to load data</Alert>;
   } else {
     explorePage = (
       <ExplorePage
@@ -193,11 +196,15 @@ export const ExploreFocusSplit = ({ isSmallScreen }: Props) => {
         sequencingIntensityEntrySet={sequencingIntensityEntrySetState.data}
       />
     );
+    deepExplorePage = (
+      <DeepExplorePage
+        country={country}
+        dateRange={dateRange}
+        samplingStrategy={samplingStrategy}
+        sequencingIntensityEntrySet={sequencingIntensityEntrySetState.data}
+      />
+    );
   }
-
-  const deepExplorePage = (
-    <DeepExplorePage country={country} dateRange={dateRange} samplingStrategy={samplingStrategy} />
-  );
 
   const makeLayout = (focusContent: React.ReactNode, deepFocusContent: React.ReactNode): JSX.Element => (
     <>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -9,15 +9,19 @@ import { NewVariantTable } from '../components/NewVariantTable';
 import { VariantSelector } from '../helpers/sample-selector';
 import { SampleSetWithSelector } from '../helpers/sample-set';
 import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
-import { isRegion, SamplingStrategy } from '../services/api';
+import { DateRange, isRegion, SamplingStrategy } from '../services/api';
 import { Country } from '../services/api-types';
 import { SequencingIntensityPlotWidget } from '../widgets/SequencingIntensityPlot';
 import { AccountService } from '../services/AccountService';
 import { VercelSponsorshipLogo } from '../components/VercelSponsorshipLogo';
+import { createLocation } from 'history';
+import { generatePath } from 'react-router';
+import { ShowMoreButton } from '../helpers/ui';
 
 interface Props {
   country: Country;
   samplingStrategy: SamplingStrategy;
+  dateRange: DateRange;
   onVariantSelect: (selection: VariantSelector) => void;
   selection: VariantSelector | undefined;
   wholeSampleSetState: AsyncState<SampleSetWithSelector>;
@@ -34,11 +38,15 @@ const Footer = styled.footer`
 export const ExplorePage = ({
   country,
   samplingStrategy,
+  dateRange,
   onVariantSelect,
   selection,
   wholeSampleSetState,
   sequencingIntensityEntrySet,
 }: Props) => {
+  const toSequencingCoverage = createLocation(
+    generatePath(`/explore/${country}/${samplingStrategy}/${dateRange}/sequencing-coverage`)
+  );
   return (
     <>
       <SequencingIntensityPlotWidget.ShareableComponent
@@ -46,6 +54,7 @@ export const ExplorePage = ({
         sequencingIntensityEntrySet={sequencingIntensityEntrySet}
         height={300}
         widgetLayout={NamedSection}
+        toolbarChildren={<ShowMoreButton to={toSequencingCoverage} />}
       />
       <NamedSection title='Known variants'>
         <KnownVariantsList

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -1,7 +1,6 @@
 import { mapValues } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { AsyncState } from 'react-async';
-import { useHistory } from 'react-router-dom';
 import { AsyncVariantInternationalComparisonPlot } from '../components/AsyncVariantInternationalComparisonPlot';
 import { ExportButton } from '../components/CombinedExport/ExportButton';
 import { ExportManager, ExportManagerContext } from '../components/CombinedExport/ExportManager';
@@ -16,7 +15,7 @@ import { VariantMutations } from '../components/VariantMutations';
 import { getFocusPageLink } from '../helpers/explore-url';
 import { SampleSetWithSelector } from '../helpers/sample-set';
 import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
-import { Alert, AlertVariant, Button, ButtonVariant } from '../helpers/ui';
+import { Alert, AlertVariant, ShowMoreButton } from '../helpers/ui';
 import { Chen2021FitnessPreview } from '../models/chen2021Fitness/Chen2021FitnessPreview';
 import { filter, getData } from '../models/wasteWater/loading';
 import { WasteWaterDataset } from '../models/wasteWater/types';
@@ -61,7 +60,6 @@ export const FocusPage = ({
   ...forwardedProps
 }: Props) => {
   const { country, matchPercentage, variant, samplingStrategy, dateRange } = forwardedProps;
-  const history = useHistory();
 
   const plotProps = {
     country,
@@ -84,19 +82,9 @@ export const FocusPage = ({
           dateRange,
           deepFocusPath: suffix,
         });
-        return (
-          <Button
-            className='mt-1 ml-2'
-            variant={ButtonVariant.PRIMARY}
-            onClick={() => {
-              history.push(to);
-            }}
-          >
-            Show more
-          </Button>
-        );
+        return <ShowMoreButton to={to} />;
       }),
-    [country, samplingStrategy, dateRange, matchPercentage, variant, history]
+    [country, samplingStrategy, dateRange, matchPercentage, variant]
   );
 
   const [wasteWaterData, setWasteWaterData] = useState<WasteWaterDataset | undefined>(undefined);

--- a/src/services/api-types.ts
+++ b/src/services/api-types.ts
@@ -1,4 +1,5 @@
 import * as zod from 'zod';
+import { LiteralSamplingStrategySchema } from './api';
 
 // Small reusable objects that aren't explicitly separate in the API doc
 
@@ -198,6 +199,7 @@ export const SequencingRepresentativenessSelectorSchema = zod.object({
   country: CountrySchema.optional(),
   dateFrom: DateStringSchema.optional(),
   dateTo: DateStringSchema.optional(),
+  samplingStrategy: LiteralSamplingStrategySchema,
 });
 
 // TypeScript types from schemas

--- a/src/services/api-types.ts
+++ b/src/services/api-types.ts
@@ -183,6 +183,19 @@ export const DataStatusSchema = zod.object({
   lastUpdateTimestamp: zod.string(),
 });
 
+export const CaseCountEntrySchema = zod.object({
+  division: zod.string().nullable(),
+  ageGroup: zod.string().nullable(),
+  sex: zod.string().nullable(),
+  count: zod.number(),
+});
+
+export const SequencingRepresentativenessSelectorSchema = zod.object({
+  country: CountrySchema.optional(),
+  dateFrom: DateStringSchema.optional(),
+  dateTo: DateStringSchema.optional(),
+});
+
 // TypeScript types from schemas
 export type ValueWithCI = zod.infer<typeof ValueWithCISchema>;
 export type CountAndProportionWithCI = zod.infer<typeof CountAndProportionWithCISchema>;
@@ -200,5 +213,9 @@ export type SequencingIntensityEntry = zod.infer<typeof SequencingIntensityEntry
 export type PangolinLineageInformation = zod.infer<typeof PangolinLineageInformationSchema>;
 export type Article = zod.infer<typeof ArticleSchema>;
 export type DataStatus = zod.infer<typeof DataStatusSchema>;
+export type CaseCountEntry = zod.infer<typeof CaseCountEntrySchema>;
+export type SequencingRepresentativenessSelector = zod.infer<
+  typeof SequencingRepresentativenessSelectorSchema
+>;
 
 export type Place = Country | Region;

--- a/src/services/api-types.ts
+++ b/src/services/api-types.ts
@@ -187,8 +187,12 @@ export const CaseCountEntrySchema = zod.object({
   division: zod.string().nullable(),
   ageGroup: zod.string().nullable(),
   sex: zod.string().nullable(),
+  hospitalized: zod.boolean().nullable(),
+  deceased: zod.boolean().nullable(),
   count: zod.number(),
 });
+
+export const SequenceCountEntrySchema = CaseCountEntrySchema;
 
 export const SequencingRepresentativenessSelectorSchema = zod.object({
   country: CountrySchema.optional(),
@@ -214,6 +218,7 @@ export type PangolinLineageInformation = zod.infer<typeof PangolinLineageInforma
 export type Article = zod.infer<typeof ArticleSchema>;
 export type DataStatus = zod.infer<typeof DataStatusSchema>;
 export type CaseCountEntry = zod.infer<typeof CaseCountEntrySchema>;
+export type SequenceCountEntry = zod.infer<typeof SequenceCountEntrySchema>;
 export type SequencingRepresentativenessSelector = zod.infer<
   typeof SequencingRepresentativenessSelectorSchema
 >;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -24,6 +24,8 @@ import {
   SequencingRepresentativenessSelector,
   CaseCountEntry,
   CaseCountEntrySchema,
+  SequenceCountEntry,
+  SequenceCountEntrySchema,
 } from './api-types';
 import dayjs from 'dayjs';
 import {
@@ -445,6 +447,30 @@ export async function getDataStatus(signal?: AbortSignal): Promise<DataStatus> {
     throw new Error('server responded with non-200 status code');
   }
   return DataStatusSchema.parse(await res.json());
+}
+
+export async function getSequenceCounts(
+  { dateFrom, dateTo, country }: SequencingRepresentativenessSelector,
+  signal?: AbortSignal
+): Promise<SequenceCountEntry[]> {
+  const params = new URLSearchParams();
+  if (country) {
+    params.set('country', country);
+  }
+  if (dateFrom) {
+    params.set('dateFrom', dateFrom);
+  }
+  if (dateTo) {
+    params.set('dateTo', dateTo);
+  }
+  const res = await get(
+    `/resource/sample2?fields=division,ageGroup,sex,hospitalized,deceased&${params.toString()}`,
+    signal
+  );
+  if (!res.ok) {
+    throw new Error('server responded with non-200 status code');
+  }
+  return zod.array(SequenceCountEntrySchema).parse(await res.json());
 }
 
 export async function getCaseCounts(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,6 +21,9 @@ import {
   ArticleSchema,
   DataStatus,
   DataStatusSchema,
+  SequencingRepresentativenessSelector,
+  CaseCountEntry,
+  CaseCountEntrySchema,
 } from './api-types';
 import dayjs from 'dayjs';
 import {
@@ -442,4 +445,27 @@ export async function getDataStatus(signal?: AbortSignal): Promise<DataStatus> {
     throw new Error('server responded with non-200 status code');
   }
   return DataStatusSchema.parse(await res.json());
+}
+
+export async function getCaseCounts(
+  { dateFrom, dateTo, country }: SequencingRepresentativenessSelector,
+  signal?: AbortSignal
+): Promise<CaseCountEntry[]> {
+  if (country !== 'Switzerland') {
+    throw new Error('getCaseCounts() is currently only available for Switzerland.');
+  }
+  const params = new URLSearchParams();
+  params.set('country', country);
+  if (dateFrom) {
+    params.set('dateFrom', dateFrom);
+  }
+  if (dateTo) {
+    params.set('dateTo', dateTo);
+  }
+  const url = '/resource/case?' + params.toString();
+  const res = await get(url, signal);
+  if (!res.ok) {
+    throw new Error('server responded with non-200 status code');
+  }
+  return zod.array(CaseCountEntrySchema).parse(await res.json());
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -450,7 +450,7 @@ export async function getDataStatus(signal?: AbortSignal): Promise<DataStatus> {
 }
 
 export async function getSequenceCounts(
-  { dateFrom, dateTo, country }: SequencingRepresentativenessSelector,
+  { dateFrom, dateTo, country, samplingStrategy }: SequencingRepresentativenessSelector,
   signal?: AbortSignal
 ): Promise<SequenceCountEntry[]> {
   const params = new URLSearchParams();
@@ -462,6 +462,9 @@ export async function getSequenceCounts(
   }
   if (dateTo) {
     params.set('dateTo', dateTo);
+  }
+  if (samplingStrategy) {
+    params.set('dataType', samplingStrategy);
   }
   const res = await get(
     `/resource/sample2?fields=division,ageGroup,sex,hospitalized,deceased&${params.toString()}`,

--- a/src/widgets/MetadataAvailabilityPlot.tsx
+++ b/src/widgets/MetadataAvailabilityPlot.tsx
@@ -7,7 +7,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import { getSequenceCounts } from '../services/api';
 import { Attribute, attributes } from './SequencingRepresentativenessPlot';
-import { ChartAndMetricsWrapper, ChartWrapper, colors, Wrapper } from '../charts/common';
+import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from '../charts/common';
 import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import Metrics, { MetricsSpacing, MetricsWrapper } from '../charts/Metrics';
 import { kFormat } from '../helpers/number';
@@ -66,6 +66,9 @@ export const MetadataAvailabilityPlot = ({ selector }: Props) => {
 
   return (
     <Wrapper>
+      <TitleWrapper id='graph_title'>
+        Proportion of sequences for which we have metadata information
+      </TitleWrapper>
       <ChartAndMetricsWrapper>
         <ChartWrapper className='-mr-4 -ml-1'>
           <ResponsiveContainer>

--- a/src/widgets/MetadataAvailabilityPlot.tsx
+++ b/src/widgets/MetadataAvailabilityPlot.tsx
@@ -1,0 +1,116 @@
+import { Widget } from './Widget';
+import { AsyncZodQueryEncoder } from '../helpers/query-encoder';
+import {
+  SequencingRepresentativenessSelector,
+  SequencingRepresentativenessSelectorSchema,
+} from '../services/api-types';
+import React, { useEffect, useState } from 'react';
+import { getSequenceCounts } from '../services/api';
+import { Attribute, attributes } from './SequencingRepresentativenessPlot';
+import { ChartAndMetricsWrapper, ChartWrapper, colors, Wrapper } from '../charts/common';
+import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import Metrics, { MetricsSpacing, MetricsWrapper } from '../charts/Metrics';
+import { kFormat } from '../helpers/number';
+import Loader from '../components/Loader';
+
+interface Props {
+  selector: SequencingRepresentativenessSelector;
+}
+
+interface PlotEntry {
+  attributeLabel: string;
+  proportion: number;
+  known: number;
+  unknown: number;
+}
+
+export const MetadataAvailabilityPlot = ({ selector }: Props) => {
+  const [data, setData] = useState<undefined | PlotEntry[]>(undefined);
+  const [active, setActive] = useState<undefined | PlotEntry>(undefined);
+
+  useEffect(() => {
+    getSequenceCounts(selector).then(counts => {
+      let total = 0;
+      const knownOfAttribute: Map<Attribute, number> = new Map(attributes.map(({ key }) => [key, 0]));
+      for (let countEntry of counts) {
+        total += countEntry.count;
+        for (let { key } of attributes) {
+          if (countEntry[key] !== null) {
+            knownOfAttribute.set(key, countEntry.count + knownOfAttribute.get(key)!);
+          }
+        }
+      }
+      const _data = attributes.map(({ key, label }) => ({
+        attributeLabel: label,
+        proportion: (knownOfAttribute.get(key)! / total) * 100,
+        known: knownOfAttribute.get(key)!,
+        unknown: total - knownOfAttribute.get(key)!,
+      }));
+      setData(_data);
+    });
+  }, [selector, setData]);
+
+  if (!data) {
+    return <Loader />;
+  }
+
+  return (
+    <Wrapper>
+      <ChartAndMetricsWrapper>
+        <ChartWrapper className='-mr-4 -ml-1'>
+          <ResponsiveContainer>
+            <BarChart layout='vertical' data={data} margin={{ left: 60, right: 30 }}>
+              <XAxis type='number' domain={[0, 100]} />
+              <YAxis interval={0} dataKey='attributeLabel' type='category' />
+              <Bar dataKey='proportion' fill='#8884d8' isAnimationActive={false}>
+                {data.map((entry: PlotEntry, index: number) => (
+                  <Cell
+                    fill={entry.attributeLabel === active?.attributeLabel ? colors.active : colors.inactive}
+                    key={`cell-${index}`}
+                  />
+                ))}
+              </Bar>
+              <Tooltip
+                active={false}
+                cursor={false}
+                content={e => {
+                  if (e.active && e.payload !== undefined) {
+                    const newActive = e.payload[0].payload;
+                    if (active?.attributeLabel !== newActive.attributeLabel) {
+                      setActive(newActive);
+                    }
+                  }
+                  if (!e.active) {
+                    setActive(undefined);
+                  }
+                  return <></>;
+                }}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartWrapper>
+        <MetricsWrapper>
+          <MetricsSpacing />
+          <Metrics
+            value={active ? kFormat(active.known) : '-'}
+            title={'Available'}
+            helpText={'Number of samples for which metadata information is available'}
+            showPercent={active ? active.proportion.toFixed(2) : '-'}
+          />
+        </MetricsWrapper>
+      </ChartAndMetricsWrapper>
+    </Wrapper>
+  );
+};
+
+export const MetadataAvailabilityPlotWidget = new Widget(
+  new AsyncZodQueryEncoder(
+    SequencingRepresentativenessSelectorSchema,
+    async (decoded: Props) => decoded.selector,
+    async encoded => ({
+      selector: encoded,
+    })
+  ),
+  MetadataAvailabilityPlot,
+  'MetadataAvailabilityPlot'
+);

--- a/src/widgets/SequencingRepresentativenessPlot.tsx
+++ b/src/widgets/SequencingRepresentativenessPlot.tsx
@@ -1,22 +1,202 @@
 import { Widget } from './Widget';
 import { AsyncZodQueryEncoder } from '../helpers/query-encoder';
 import {
+  CaseCountEntry,
+  SequenceCountEntry,
   SequencingRepresentativenessSelector,
   SequencingRepresentativenessSelectorSchema,
 } from '../services/api-types';
-import { useEffect } from 'react';
-import { getCaseCounts } from '../services/api';
+import React, { useEffect, useState } from 'react';
+import { getCaseCounts, getSequenceCounts } from '../services/api';
+import { Form } from 'react-bootstrap';
+import { Utils } from '../services/Utils';
+import { ChartAndMetricsWrapper, ChartWrapper, colors, Wrapper } from '../charts/common';
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis, Text, Cell } from 'recharts';
+import Metrics, { MetricsWrapper } from '../charts/Metrics';
+import Loader from '../components/Loader';
+import { kFormat } from '../helpers/number';
 
 interface Props {
   selector: SequencingRepresentativenessSelector;
 }
 
-export const SequencingRepresentativenessPlot = ({ selector }: Props) => {
+interface PlotEntry {
+  key: string;
+  proportion?: number;
+  sequenced: number;
+  cases: number;
+}
+
+type Attribute = 'division' | 'ageGroup' | 'sex' | 'hospitalized' | 'deceased';
+
+const attributes: {
+  key: Attribute;
+  label: string;
+}[] = [
+  { key: 'division', label: 'Division' },
+  { key: 'ageGroup', label: 'Age group' },
+  { key: 'sex', label: 'Sex' },
+  { key: 'hospitalized', label: 'Hospitalized' },
+  { key: 'deceased', label: 'Deceased' },
+];
+
+function prepareCountsData(
+  counts: CaseCountEntry[] | SequenceCountEntry[],
+  attributes: Attribute[]
+): Map<string, number> {
+  const grouped = Utils.groupBy(counts, el => {
+    const keyValues = [];
+    for (let attribute of attributes) {
+      const value = el[attribute];
+      if (value === null) {
+        return '';
+      }
+      if (attribute === 'hospitalized') {
+        keyValues.push(value ? 'hospitalized' : 'not hospitalized');
+      } else if (attribute === 'deceased') {
+        keyValues.push(value ? 'died' : 'not died');
+      } else {
+        keyValues.push(value);
+      }
+    }
+    return keyValues.join('/');
+  });
+  const aggregated: [string, number][] = [...grouped.entries()]
+    .filter(([key]) => key !== '')
+    .map(([key, entries]) => [key, entries.reduce((count, entry) => count + entry.count, 0)]);
+  aggregated.sort(([key1], [key2]) => (key1 < key2 ? -1 : 1));
+  return new Map(aggregated);
+}
+
+export const SequencingRepresentativenessPlot = React.memo(({ selector }: Props) => {
+  const [data, setData] = useState<undefined | PlotEntry[]>(undefined);
+  const [active, setActive] = useState<undefined | PlotEntry>(undefined);
+  const [selectedAttributes, setSelectedAttributes] = useState<Attribute[]>(['division']);
+
   useEffect(() => {
-    getCaseCounts(selector).then(caseCounts => console.log(caseCounts));
-  }, [selector]);
-  return <></>;
-};
+    const caseCountsPromise = getCaseCounts(selector).then(counts =>
+      prepareCountsData(counts, selectedAttributes)
+    );
+    const sequenceCountsPromise = getSequenceCounts(selector).then(counts =>
+      prepareCountsData(counts, selectedAttributes)
+    );
+    Promise.all([caseCountsPromise, sequenceCountsPromise]).then(([caseCounts, sequenceCounts]) => {
+      const _data: PlotEntry[] = [];
+      for (let [key, cases] of caseCounts) {
+        const sequenced = sequenceCounts.get(key) ?? 0;
+        const proportion = cases > 0 ? (sequenced / cases) * 100 : undefined;
+        _data.push({
+          key,
+          cases,
+          sequenced,
+          proportion,
+        });
+      }
+      setData(_data);
+    });
+  }, [selector, selectedAttributes]);
+
+  const YAxisLeftTick = ({ y, payload: { value } }: any) => {
+    return (
+      <Text x={300} y={y} textAnchor='end' verticalAnchor='middle'>
+        {value}
+      </Text>
+    );
+  };
+
+  const selectOrUnselectAttribute = (attribute: Attribute) => {
+    // Only up to up attributes may be selected at the same time
+    // If a third item is being checked, the first will be unchecked
+    const [first, second] = selectedAttributes;
+    if (attribute === first) {
+      setSelectedAttributes([second]);
+    } else if (attribute === second) {
+      setSelectedAttributes([first]);
+    } else if (!first) {
+      setSelectedAttributes([attribute]);
+    } else if (!second) {
+      setSelectedAttributes([first, attribute]);
+    } else {
+      setSelectedAttributes([second, attribute]);
+    }
+  };
+
+  return (
+    <div className='flex h-full'>
+      <div>
+        <div>Select up to two attributes:</div>
+        {attributes.map(({ key, label }) => (
+          <Form.Check
+            key={key}
+            type='checkbox'
+            id={key + '-checkbox'}
+            label={label}
+            checked={selectedAttributes.includes(key)}
+            onChange={() => selectOrUnselectAttribute(key)}
+          />
+        ))}
+      </div>
+      <div className='flex-grow overflow-auto'>
+        {!data && <Loader />}
+        {data && (
+          <div style={{ height: `${data.length * 25}px` }} key={data.length}>
+            <Wrapper>
+              <ChartAndMetricsWrapper>
+                <ChartWrapper className='-mr-4 -ml-1'>
+                  <ResponsiveContainer>
+                    <BarChart data={data} layout='vertical' margin={{ left: 250, right: 50 }}>
+                      <XAxis type='number' />
+                      <YAxis interval={0} dataKey='key' type='category' tick={YAxisLeftTick} />
+                      <Bar dataKey='proportion' fill='#8884d8' isAnimationActive={false}>
+                        {data.map((entry: PlotEntry, index: number) => (
+                          <Cell
+                            fill={entry.key === active?.key ? colors.active : colors.inactive}
+                            key={`cell-${index}`}
+                          />
+                        ))}
+                      </Bar>
+                      <Tooltip
+                        active={false}
+                        cursor={false}
+                        content={e => {
+                          if (e.active && e.payload !== undefined) {
+                            const newActive = e.payload[0].payload;
+                            if (active?.key !== newActive.key) {
+                              setActive(newActive);
+                            }
+                          }
+                          if (!e.active) {
+                            setActive(undefined);
+                          }
+                          return <></>;
+                        }}
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartWrapper>
+              </ChartAndMetricsWrapper>
+            </Wrapper>
+          </div>
+        )}
+      </div>
+      <div className='h-full flex'>
+        <MetricsWrapper className='ml-10'>
+          <Metrics
+            value={active ? kFormat(active.cases) : '-'}
+            title={'Confirmed'}
+            helpText={'Number of confirmed cases'}
+          />
+          <Metrics
+            value={active ? kFormat(active.sequenced) : '-'}
+            title={'Sequenced'}
+            helpText={'Number of samples sequenced among the confirmed cases'}
+            showPercent={active && active.proportion ? active.proportion.toFixed(2) : '-'}
+          />
+        </MetricsWrapper>
+      </div>
+    </div>
+  );
+});
 
 export const SequencingRepresentativenessPlotWidget = new Widget(
   new AsyncZodQueryEncoder(

--- a/src/widgets/SequencingRepresentativenessPlot.tsx
+++ b/src/widgets/SequencingRepresentativenessPlot.tsx
@@ -74,6 +74,9 @@ export const SequencingRepresentativenessPlot = React.memo(({ selector }: Props)
   const [selectedAttributes, setSelectedAttributes] = useState<Attribute[]>(['division']);
 
   useEffect(() => {
+    if (selector.country !== 'Switzerland') {
+      return;
+    }
     const caseCountsPromise = getCaseCounts(selector).then(counts =>
       prepareCountsData(counts, selectedAttributes)
     );
@@ -95,6 +98,10 @@ export const SequencingRepresentativenessPlot = React.memo(({ selector }: Props)
       setData(_data);
     });
   }, [selector, selectedAttributes]);
+
+  if (selector.country !== 'Switzerland') {
+    return <>This plot is only available for Switzerland.</>;
+  }
 
   const YAxisLeftTick = ({ y, payload: { value } }: any) => {
     return (

--- a/src/widgets/SequencingRepresentativenessPlot.tsx
+++ b/src/widgets/SequencingRepresentativenessPlot.tsx
@@ -1,0 +1,29 @@
+import { Widget } from './Widget';
+import { AsyncZodQueryEncoder } from '../helpers/query-encoder';
+import { SequencingIntensityEntrySetSelectorSchema } from '../helpers/sequencing-intensity-entry-set';
+import { SequencingRepresentativenessSelector } from '../services/api-types';
+import { useEffect } from 'react';
+import { getCaseCounts } from '../services/api';
+
+interface Props {
+  selector: SequencingRepresentativenessSelector;
+}
+
+export const SequencingRepresentativenessPlot = ({ selector }: Props) => {
+  useEffect(() => {
+    getCaseCounts(selector).then(caseCounts => console.log(caseCounts));
+  }, [selector]);
+  return <></>;
+};
+
+export const SequencingRepresentativenessPlotWidget = new Widget(
+  new AsyncZodQueryEncoder(
+    SequencingIntensityEntrySetSelectorSchema,
+    async (decoded: Props) => decoded.selector,
+    async encoded => ({
+      selector: encoded,
+    })
+  ),
+  SequencingRepresentativenessPlot,
+  'SequencingRepresentativenessPlot'
+);

--- a/src/widgets/SequencingRepresentativenessPlot.tsx
+++ b/src/widgets/SequencingRepresentativenessPlot.tsx
@@ -27,17 +27,17 @@ interface PlotEntry {
   cases: number;
 }
 
-type Attribute = 'division' | 'ageGroup' | 'sex' | 'hospitalized' | 'deceased';
+export type Attribute = 'division' | 'ageGroup' | 'sex' | 'hospitalized' | 'deceased';
 
-const attributes: {
+export const attributes: {
   key: Attribute;
   label: string;
 }[] = [
   { key: 'division', label: 'Division' },
   { key: 'ageGroup', label: 'Age group' },
   { key: 'sex', label: 'Sex' },
-  { key: 'hospitalized', label: 'Hospitalized' },
-  { key: 'deceased', label: 'Deceased' },
+  { key: 'hospitalized', label: 'Hospitalization status' },
+  { key: 'deceased', label: 'Death status' },
 ];
 
 function prepareCountsData(

--- a/src/widgets/SequencingRepresentativenessPlot.tsx
+++ b/src/widgets/SequencingRepresentativenessPlot.tsx
@@ -1,7 +1,9 @@
 import { Widget } from './Widget';
 import { AsyncZodQueryEncoder } from '../helpers/query-encoder';
-import { SequencingIntensityEntrySetSelectorSchema } from '../helpers/sequencing-intensity-entry-set';
-import { SequencingRepresentativenessSelector } from '../services/api-types';
+import {
+  SequencingRepresentativenessSelector,
+  SequencingRepresentativenessSelectorSchema,
+} from '../services/api-types';
 import { useEffect } from 'react';
 import { getCaseCounts } from '../services/api';
 
@@ -18,7 +20,7 @@ export const SequencingRepresentativenessPlot = ({ selector }: Props) => {
 
 export const SequencingRepresentativenessPlotWidget = new Widget(
   new AsyncZodQueryEncoder(
-    SequencingIntensityEntrySetSelectorSchema,
+    SequencingRepresentativenessSelectorSchema,
     async (decoded: Props) => decoded.selector,
     async encoded => ({
       selector: encoded,

--- a/src/widgets/SequencingRepresentativenessPlot.tsx
+++ b/src/widgets/SequencingRepresentativenessPlot.tsx
@@ -146,7 +146,7 @@ export const SequencingRepresentativenessPlot = React.memo(({ selector }: Props)
       <div className='flex-grow overflow-auto'>
         {!data && <Loader />}
         {data && (
-          <div style={{ height: `${data.length * 25}px` }} key={data.length}>
+          <div style={{ height: `${30 + data.length * 25}px` }} key={data.length}>
             <Wrapper>
               <ChartAndMetricsWrapper>
                 <ChartWrapper className='-mr-4 -ml-1'>

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -11,6 +11,7 @@ import { VariantDivisionDistributionTableWidget } from './VariantDivisionDistrib
 import { WasteWaterSummaryTimeWidget } from '../models/wasteWater/WasteWaterSummaryTimeWidget';
 import { WasteWaterLocationTimeWidget } from '../models/wasteWater/WasteWaterLocationTimeWidget';
 import { HospitalizationDeathPlotWidget } from './HospitalizationDeathPlot';
+import { SequencingRepresentativenessPlotWidget } from './SequencingRepresentativenessPlot';
 
 export const allWidgets = [
   VariantAgeDistributionPlotWidget,
@@ -18,6 +19,7 @@ export const allWidgets = [
   VariantTimeDistributionPlotWidget,
   VariantDivisionDistributionTableWidget,
   SequencingIntensityPlotWidget,
+  SequencingRepresentativenessPlotWidget,
   Chen2021FitnessWidget,
   WasteWaterTimeWidget,
   WasteWaterHeatMapWidget,

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -12,6 +12,7 @@ import { WasteWaterSummaryTimeWidget } from '../models/wasteWater/WasteWaterSumm
 import { WasteWaterLocationTimeWidget } from '../models/wasteWater/WasteWaterLocationTimeWidget';
 import { HospitalizationDeathPlotWidget } from './HospitalizationDeathPlot';
 import { SequencingRepresentativenessPlotWidget } from './SequencingRepresentativenessPlot';
+import { MetadataAvailabilityPlotWidget } from './MetadataAvailabilityPlot';
 
 export const allWidgets = [
   VariantAgeDistributionPlotWidget,
@@ -20,6 +21,7 @@ export const allWidgets = [
   VariantDivisionDistributionTableWidget,
   SequencingIntensityPlotWidget,
   SequencingRepresentativenessPlotWidget,
+  MetadataAvailabilityPlotWidget,
   Chen2021FitnessWidget,
   WasteWaterTimeWidget,
   WasteWaterHeatMapWidget,


### PR DESCRIPTION
This PR adds a "deep" page which is linked from the "show more" button of the sequencing intensity plot. Because the `DeepFocusPage` is variant-specific, I introduced the `DeepExplorePage`.

The aim of the new `SequencingCoverageDeepExplore`-page is to give an overview of the quality/completeness/representativeness of the data. It contains the `MetadataAvailabilityPlot` which is available for all countries (closes #162) and the `SequencingRepresentativenessPlot` which is only available for Switzerland (closes #154).

![image](https://user-images.githubusercontent.com/18666552/121003471-def75780-c78d-11eb-9e1b-4879761140da.png)
