### PR TITLE
Fix estimated cases plot date range filter bug

### DIFF
--- a/src/charts/EstimatedCasesChart.tsx
+++ b/src/charts/EstimatedCasesChart.tsx
@@ -7,7 +7,6 @@ import { getTicks } from '../helpers/ticks';
 import { calculateWilsonInterval } from '../helpers/wilson-interval';
 import dayjs from 'dayjs';
 import DownloadWrapper from './DownloadWrapper';
-import { Utils } from '../services/Utils';
 import { Alert, AlertVariant } from '../helpers/ui';
 
 export type EstimatedCasesTimeEntry = {
@@ -49,8 +48,9 @@ export const EstimatedCasesChart = React.memo(
     } = useMemo(() => {
       // Only show the data after the variant was first identified
       const sortedData = [...data].sort((a, b) => (a.date.dayjs.isAfter(b.date.dayjs) ? 1 : -1));
-      let filteredData: EstimatedCasesTimeEntry[] = Utils.trimStartBy(sortedData, x => x.variantCount === 0);
-      filteredData = Utils.trimEndBy(filteredData, x => x.sequenced === 0);
+      let filteredData: EstimatedCasesTimeEntry[] = sortedData.filter(
+        d => d.variantCount > 0 && d.sequenced > 0
+      );
       const smoothedData: EstimatedCasesTimeEntry[] = [];
       for (let i = 3; i < filteredData.length - 3; i++) {
         const window = [


### PR DESCRIPTION
Fix for #126
I replaced the code using `Utils.trimStartBy` and `Utils.trimEndBy` with using `filter`

![image](https://user-images.githubusercontent.com/3387698/129327823-4975e39c-3b53-44b2-adf1-9344c9e75ad1.png)
