### PR TITLE
UI error handling (bug fix)

### DIFF
--- a/src/components/KnownVariantsList/KnownVariantsList.tsx
+++ b/src/components/KnownVariantsList/KnownVariantsList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { AsyncState } from 'react-async';
 import styled from 'styled-components';
 import { VariantSelector } from '../../helpers/sample-selector';
@@ -118,7 +118,6 @@ export const KnownVariantsList = ({
 
   const {
     isFetching: isPLFetching,
-    refetch: plRefetch,
     isError: isPLError,
     error: pLError,
     isLoading: isPLLoading,
@@ -149,7 +148,6 @@ export const KnownVariantsList = ({
 
   const {
     isFetching: isKVFetching,
-    refetch: kVRefetch,
     isError: isKVError,
     error: kVError,
     isLoading: isKVLoading,
@@ -158,20 +156,6 @@ export const KnownVariantsList = ({
     ['knownVariantsSampleSets', country, samplingStrategy, knownVariantSelectors],
     fetchKnownVariantSampleSets
   );
-
-  useEffect(() => {
-    if (!isPLFetching) {
-      plRefetch();
-    }
-    // eslint-disable-next-line
-  }, [country, samplingStrategy, selectedVariantList]);
-
-  useEffect(() => {
-    if (!isKVFetching) {
-      kVRefetch();
-    }
-    // eslint-disable-next-line
-  }, [country, samplingStrategy, knownVariantSelectors]);
 
   const knownVariants = useMemo(() => {
     if (variantSampleSets === undefined || !wholeSampleSetState.isResolved) {

--- a/src/components/SampleTable.tsx
+++ b/src/components/SampleTable.tsx
@@ -62,7 +62,7 @@ interface Props {
 // SampleTable shows detailed information about individual samples from GISAID
 export const SampleTable = ({ matchPercentage, variant, country, samplingStrategy }: Props) => {
   const mutationsString = variant.mutations.join(',');
-  const { isLoading, isSuccess, error, isError, data: samples, refetch, isFetching } = useQuery<
+  const { isLoading, isSuccess, error, isError, data: samples, isFetching } = useQuery<
     SampleResultList,
     Error
   >(['samples', matchPercentage, variant.name, variant.mutations, country, samplingStrategy], () => {
@@ -81,13 +81,6 @@ export const SampleTable = ({ matchPercentage, variant, country, samplingStrateg
     (promise as PromiseWithCancel<SampleResultList>).cancel = () => controller.abort();
     return promise;
   });
-
-  useEffect(() => {
-    if (!isFetching) {
-      refetch();
-    }
-    // eslint-disable-next-line
-  }, [matchPercentage, variant.name, variant.mutations, country, samplingStrategy]);
 
   const [popoverTarget, setPopoverTarget] = useState<PopoverTarget>();
   useEffect(() => {

--- a/src/components/SwitzerlandEstimatedCasesDivisionModal.tsx
+++ b/src/components/SwitzerlandEstimatedCasesDivisionModal.tsx
@@ -4,7 +4,7 @@ import {
   SequencingIntensityEntrySetWithSelector,
 } from '../helpers/sequencing-intensity-entry-set';
 import { getCaseCounts, PromiseWithCancel } from '../services/api';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { AlmostFullscreenModal } from './AlmostFullscreenModal';
 import { CaseCountEntry } from '../services/api-types';
 import { Utils } from '../services/Utils';
@@ -91,7 +91,7 @@ export const SwitzerlandEstimatedCasesDivisionModal = ({
   const [showSwissRegions, setShowSwissRegions] = useState(true);
   const { dateFrom, dateTo, country } = variantSampleSet.sampleSelector;
 
-  const { isLoading, isSuccess, error, isError, data: caseCounts, refetch, isFetching } = useQuery<
+  const { isLoading, isSuccess, error, isError, data: caseCounts, isFetching } = useQuery<
     CaseCountEntry[],
     Error
   >(['caseCounts', dateFrom, dateTo, country], () => {
@@ -101,13 +101,6 @@ export const SwitzerlandEstimatedCasesDivisionModal = ({
     (promise as PromiseWithCancel<CaseCountEntry[]>).cancel = () => controller.abort();
     return promise;
   });
-
-  useEffect(() => {
-    if (!isFetching) {
-      refetch();
-    }
-    // eslint-disable-next-line
-  }, [dateFrom, dateTo, country]);
 
   const { cantonData, regionData } = useMemo(() => {
     if (!caseCounts) {

--- a/src/components/VariantLineages.tsx
+++ b/src/components/VariantLineages.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Country, PangolinLineageList, Variant } from '../services/api-types';
 import {
   DateRange,
@@ -55,7 +55,7 @@ export const VariantLineages = ({
   >([]);
   const { dateFrom, dateTo } = dateRangeToDates(dateRange);
 
-  const { isLoading, error, isError, isSuccess, refetch, isFetching } = useQuery<PangolinLineageList, Error>(
+  const { isLoading, error, isError, isSuccess, isFetching } = useQuery<PangolinLineageList, Error>(
     ['pangolinLineages', country, matchPercentage, variant, samplingStrategy, dateFrom, dateTo],
     () => {
       const controller = new AbortController();
@@ -64,7 +64,11 @@ export const VariantLineages = ({
         {
           country,
           samplingStrategy,
-          dateFrom: dayjs().subtract(3, 'months').weekday(0).format('YYYY-MM-DD'),
+          pangolinLineage: variant.name,
+          dateFrom: dateFrom && dayjs(dateFrom).format('YYYY-MM-DD'),
+          dateTo: dateTo && dayjs(dateTo).format('YYYY-MM-DD'),
+          mutationsString: variant.mutations.join(','),
+          matchPercentage,
         },
         signal
       ).then(rawData => {
@@ -81,13 +85,6 @@ export const VariantLineages = ({
       return promise;
     }
   );
-
-  useEffect(() => {
-    if (!isFetching) {
-      refetch();
-    }
-    // eslint-disable-next-line
-  }, [country, matchPercentage, variant, samplingStrategy, dateFrom, dateTo]);
 
   return (
     <>

--- a/src/components/VariantSearch.tsx
+++ b/src/components/VariantSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import AsyncSelect from 'react-select/async';
 import { components } from 'react-select';
 import { isValidMutation } from '../helpers/mutation';
@@ -46,7 +46,7 @@ export const VariantSearch = ({ onVariantSelect }: Props) => {
   const [inputValue, setInputValue] = useState<string>('');
   const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false);
 
-  const { isLoading, error, isError, isSuccess, refetch, isFetching } = useQuery<PangolinLineageList, Error>(
+  const { isLoading, error, isError, isSuccess, isFetching } = useQuery<PangolinLineageList, Error>(
     'knownPangolinLineages',
     () => {
       const controller = new AbortController();
@@ -69,13 +69,6 @@ export const VariantSearch = ({ onVariantSelect }: Props) => {
       return promise;
     }
   );
-
-  useEffect(() => {
-    if (!isFetching) {
-      refetch();
-    }
-    // eslint-disable-next-line
-  }, []);
 
   const suggestPangolinLineages = (query: string): string[] => {
     return pangolinLineages.filter(pl => pl.toUpperCase().startsWith(query.toUpperCase()));

--- a/src/widgets/MetadataAvailabilityPlot.tsx
+++ b/src/widgets/MetadataAvailabilityPlot.tsx
@@ -5,7 +5,7 @@ import {
   SequencingRepresentativenessSelector,
   SequencingRepresentativenessSelectorSchema,
 } from '../services/api-types';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { getSequenceCounts, PromiseWithCancel } from '../services/api';
 import { Attribute, attributes } from './SequencingRepresentativenessPlot';
 import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from '../charts/common';
@@ -58,17 +58,10 @@ export const MetadataAvailabilityPlot = ({ selector }: Props) => {
     return promise;
   };
 
-  const { isFetching, refetch, isError, error, isLoading, isSuccess } = useQuery<SequenceCountEntry[], Error>(
+  const { isFetching, isError, error, isLoading, isSuccess } = useQuery<SequenceCountEntry[], Error>(
     ['sequenceCounts', selector, setData],
     fetchSequenceCounts
   );
-
-  useEffect(() => {
-    if (!isFetching) {
-      refetch();
-    }
-    // eslint-disable-next-line
-  }, [selector, setData]);
 
   if (isLoading || isFetching) {
     return <Loader />;

--- a/src/widgets/SequencingRepresentativenessPlot.tsx
+++ b/src/widgets/SequencingRepresentativenessPlot.tsx
@@ -137,15 +137,6 @@ export const SequencingRepresentativenessPlot = React.memo(({ selector }: Props)
     if (selector.country !== 'Switzerland') {
       return;
     }
-
-    if (!isCCFetching) {
-      cCRefetch();
-    }
-
-    if (!isSCFetching) {
-      sCRefetch();
-    }
-    // eslint-disable-next-line
   }, [selector, selectedAttributes]);
 
   if (selector.country !== 'Switzerland') {

--- a/src/widgets/SequencingRepresentativenessPlot.tsx
+++ b/src/widgets/SequencingRepresentativenessPlot.tsx
@@ -88,7 +88,6 @@ export const SequencingRepresentativenessPlot = React.memo(({ selector }: Props)
   const {
     data: caseCounts,
     isFetching: isCCFetching,
-    refetch: cCRefetch,
     isError: isCCError,
     error: cCError,
     isLoading: isCCLoading,
@@ -122,7 +121,6 @@ export const SequencingRepresentativenessPlot = React.memo(({ selector }: Props)
 
   const {
     isFetching: isSCFetching,
-    refetch: sCRefetch,
     isError: isSCError,
     error: sCError,
     isLoading: isSCLoading,


### PR DESCRIPTION
Fix bugs for #225

1. With dependencies added query keys for useQuery (React-Query), we don't need to keep the useEffect hooks to call the refetch function. The React-Query hooks will refetch when the dependencies mentioned in the query keys change.
2. Fix the VariantLineages query parameters