### PR TITLE
Decouple the KnownVariantList from the Date Range Selector

### DIFF
--- a/src/components/KnownVariantsList/KnownVariantsList.tsx
+++ b/src/components/KnownVariantsList/KnownVariantsList.tsx
@@ -86,11 +86,6 @@ function selectPreviewVariants(
  * of weeks, we need to fetch slightly more here to ensure we have enough. Therefore,
  * we use past 3 months (Past3M) as the date range across all API calls within KnownVariantsList,
  * e.g. useWholeSampleSet, getPangolinLineages, loadKnownVariantSampleSets.
- * @param country
- * @param samplingStrategy
- * @param onVariantSelect
- * @param selection
- * @constructor
  */
 export const KnownVariantsList = ({ country, samplingStrategy, onVariantSelect, selection }: Props) => {
   const [selectedVariantList, setSelectedVariantList] = useState(VARIANT_LISTS[0].name);

--- a/src/components/KnownVariantsList/load-data.ts
+++ b/src/components/KnownVariantsList/load-data.ts
@@ -25,10 +25,14 @@ export async function loadKnownVariantSampleSets<T extends VariantSelector>(
     variantSelectors,
     country,
     samplingStrategy,
+    dateFrom,
+    dateTo,
   }: {
     variantSelectors: T[];
     country: Country;
     samplingStrategy: SamplingStrategy;
+    dateFrom?: string;
+    dateTo?: string;
   },
   signal?: AbortSignal
 ): Promise<KnownVariantWithSampleSet<T>[]> {
@@ -41,10 +45,8 @@ export async function loadKnownVariantSampleSets<T extends VariantSelector>(
           mutations: selector.variant.mutations,
           pangolinLineage: selector.variant.name,
           dataType: toLiteralSamplingStrategy(samplingStrategy),
-          // We don't need very old data, since convertKnownVariantChartData will only
-          // take the latest 2 months. However since our data collection lags by a couple
-          // of weeks, we need to fetch slightly more here to ensure we have enough.
-          dateFrom: dayjs().subtract(3, 'months').weekday(0).format('YYYY-MM-DD'),
+          dateFrom, // past 3 months
+          dateTo, // undefined
         },
         signal
       )

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -71,7 +71,7 @@ function useVariantSampleSet({
   return useAsync(promiseFn);
 }
 
-function useWholeSampleSet({
+export function useWholeSampleSet({
   country,
   samplingStrategy,
   dateRange,
@@ -193,7 +193,6 @@ export const ExploreFocusSplit = ({ isSmallScreen }: Props) => {
         dateRange={dateRange}
         onVariantSelect={onVariantSelect}
         selection={variantSelector}
-        wholeSampleSetState={wholeSampleSetState}
         sequencingIntensityEntrySet={sequencingIntensityEntrySetState.data}
       />
     );

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { AsyncState } from 'react-async';
 import styled from 'styled-components';
 import { ExternalLink } from '../components/ExternalLink';
 import { KnownVariantsList } from '../components/KnownVariantsList/KnownVariantsList';
@@ -7,7 +6,6 @@ import { MutationLookup } from '../components/MutationLookup';
 import { NamedSection } from '../components/NamedSection';
 import { NewVariantTable } from '../components/NewVariantTable';
 import { VariantSelector } from '../helpers/sample-selector';
-import { SampleSetWithSelector } from '../helpers/sample-set';
 import { SequencingIntensityEntrySetWithSelector } from '../helpers/sequencing-intensity-entry-set';
 import { DateRange, isRegion, SamplingStrategy } from '../services/api';
 import { Country } from '../services/api-types';
@@ -25,7 +23,6 @@ interface Props {
   dateRange: DateRange;
   onVariantSelect: (selection: VariantSelector) => void;
   selection: VariantSelector | undefined;
-  wholeSampleSetState: AsyncState<SampleSetWithSelector>;
   sequencingIntensityEntrySet: SequencingIntensityEntrySetWithSelector;
 }
 
@@ -42,7 +39,6 @@ export const ExplorePage = ({
   dateRange,
   onVariantSelect,
   selection,
-  wholeSampleSetState,
   sequencingIntensityEntrySet,
 }: Props) => {
   const toSequencingCoverage = createLocation(
@@ -59,7 +55,6 @@ export const ExplorePage = ({
           samplingStrategy={samplingStrategy}
           onVariantSelect={onVariantSelect}
           selection={selection}
-          wholeSampleSetState={wholeSampleSetState}
         />
       </NamedSection>
       <SequencingIntensityPlotWidget.ShareableComponent


### PR DESCRIPTION
Fix for #98

1. Moved wholeSampleSet data loading from `ExploreFocusSplit` to the `KnownVariantList`
2. Set the dateRange to be `Past3M` across all API calls within `KnownVariantList` so it's not defined everywhere


![image](https://user-images.githubusercontent.com/3387698/134141257-adab1831-da22-46f6-b29c-ce019e158370.png)


![image](https://user-images.githubusercontent.com/3387698/134141797-c87e8186-cd73-4ee2-a4eb-9931f2f45689.png)
