### PR TITLE
Calculate Jaccard similarity as uniqueness score for mutations

### DIFF
--- a/src/components/KnownVariantsList/KnownVariantsList.tsx
+++ b/src/components/KnownVariantsList/KnownVariantsList.tsx
@@ -183,7 +183,6 @@ export const KnownVariantsList = ({
       return [];
     }
     const variantList = VARIANT_LISTS.filter(({ name }) => name === selectedVariantList)[0];
-    console.log(1);
     return selectPreviewVariants(
       variantList.variants,
       pangoCountDataset.data.getPayload(),

--- a/src/components/VariantMutations.tsx
+++ b/src/components/VariantMutations.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { MutationName } from './MutationName';
 import { sortListByAAMutation } from '../helpers/aa-mutation';
@@ -6,6 +6,11 @@ import { LocationDateVariantSelector } from '../data/LocationDateVariantSelector
 import { MutationProportionDataset } from '../data/MutationProportionDataset';
 import Loader from './Loader';
 import { useQuery } from '../helpers/query-hook';
+import { MutationProportionEntry } from '../data/MutationProportionEntry';
+import { fetchSamplesCount } from '../data/api-lapis';
+import { SequenceType } from '../data/SequenceType';
+import { VariantSelector } from '../data/VariantSelector';
+import { PromiseQueue } from '../helpers/PromiseQueue';
 
 export interface Props {
   selector: LocationDateVariantSelector;
@@ -21,25 +26,81 @@ const MutationEntry = styled.li`
   width: 250px;
 `;
 
-export const VariantMutations = ({ selector }: Props) => {
-  const [commonMutationsSort, setCommonMutationsSort] = useState<'proportion' | 'position'>('position');
-  const [commonNucMutationsSort, setCommonNucMutationsSort] = useState<'proportion' | 'position'>('position');
+const sortOptions = ['position', 'proportion', 'uniqueness'] as const;
+const sortOptionCssClass = {
+  position: '',
+  proportion: 'font-bold text-yellow-700',
+  uniqueness: 'font-bold text-indigo-600',
+};
+const sortOptionLabels = {
+  position: 'position',
+  proportion: 'proportion',
+  uniqueness: 'Jaccard similarity',
+};
+type SortOptions = typeof sortOptions[number];
 
-  const data = useQuery(
+type MutationUniquenessMap = {
+  [key: string]: number | undefined;
+};
+
+export const VariantMutations = ({ selector }: Props) => {
+  const [commonAAMutationsSort, setCommonAAMutationsSort] = useState<SortOptions>('position');
+  const [commonNucMutationsSort, setCommonNucMutationsSort] = useState<SortOptions>('position');
+  const [aaMutationUniqueness, setAAMutationUniqueness] = useState<MutationUniquenessMap>({});
+  const [nucMutationUniqueness, setNucMutationUniqueness] = useState<MutationUniquenessMap>({});
+
+  const queryStatus = useQuery(
     signal =>
       Promise.all([
+        fetchSamplesCount(selector, signal),
         MutationProportionDataset.fromApi(selector, 'aa', signal),
         MutationProportionDataset.fromApi(selector, 'nuc', signal),
-      ]).then(([aaMutationDataset, nucMutationDataset]) => ({
-        aa: aaMutationDataset.getPayload(),
-        nuc: nucMutationDataset.getPayload(),
-      })),
+      ]).then(([variantCount, aaMutationDataset, nucMutationDataset]) => {
+        return {
+          variantCount,
+          aa: aaMutationDataset.getPayload(),
+          nuc: nucMutationDataset.getPayload(),
+        };
+      }),
     [selector]
   );
 
-  if (data.isLoading || !data.data) {
+  useEffect(() => {
+    if (!queryStatus.data) {
+      return;
+    }
+    const { aa, nuc, variantCount } = queryStatus.data;
+    // aa
+    // We use a PromiseQueue because fetching the count of all mutations can be very costly (for the server).
+    const aaFetchQueue = new PromiseQueue();
+    for (let aaElement of aa) {
+      aaFetchQueue.addTask(() =>
+        fetchUniquenessScore(aaElement, selector, variantCount, 'aa').then(uniqueness =>
+          setAAMutationUniqueness(prev => ({
+            ...prev,
+            [aaElement.mutation]: uniqueness,
+          }))
+        )
+      );
+    }
+    // nuc
+    const nucFetchQueue = new PromiseQueue();
+    for (let nucElement of nuc) {
+      nucFetchQueue.addTask(() =>
+        fetchUniquenessScore(nucElement, selector, variantCount, 'nuc').then(uniqueness =>
+          setNucMutationUniqueness(prev => ({
+            ...prev,
+            [nucElement.mutation]: uniqueness,
+          }))
+        )
+      );
+    }
+  }, [queryStatus.data, selector]);
+
+  if (queryStatus.isLoading || !queryStatus.data) {
     return <Loader />;
   }
+  const data = queryStatus.data;
 
   return (
     <>
@@ -47,71 +108,152 @@ export const VariantMutations = ({ selector }: Props) => {
         The following (amino acid) mutations are present in at least 5% of the sequences of this variant:
       </div>
       <div className='ml-4'>
-        <span
-          className={commonMutationsSort === 'proportion' ? 'font-bold' : 'underline cursor-pointer'}
-          onClick={() => setCommonMutationsSort('proportion')}
-        >
-          Sort by proportion
-        </span>{' '}
-        |{' '}
-        <span
-          className={commonMutationsSort === 'position' ? 'font-bold' : 'underline cursor-pointer'}
-          onClick={() => setCommonMutationsSort('position')}
-        >
-          Sort by position
-        </span>
+        {sortOptions.map((opt, index) => (
+          <>
+            {index > 0 && <> | </>}
+            <span
+              key={opt}
+              className={commonAAMutationsSort === opt ? 'font-bold' : 'underline cursor-pointer'}
+              onClick={() => setCommonAAMutationsSort(opt)}
+            >
+              Sort by <span className={sortOptionCssClass[opt]}>{sortOptionLabels[opt]}</span>
+            </span>{' '}
+          </>
+        ))}
       </div>
       <MutationList className='list-disc'>
-        {(commonMutationsSort === 'proportion'
-          ? data.data.aa.sort((a, b) => b.proportion - a.proportion)
-          : sortListByAAMutation(data.data.aa, x => x.mutation)
-        ).map(({ mutation, proportion }) => {
-          return (
-            <MutationEntry key={mutation}>
-              <MutationName mutation={mutation} /> ({(proportion * 100).toFixed(2)}%)
-            </MutationEntry>
-          );
-        })}
+        {sortAAMutations(data.aa, commonAAMutationsSort, aaMutationUniqueness).map(
+          ({ mutation, proportion }) => {
+            return (
+              <MutationEntry key={mutation}>
+                <MutationName mutation={mutation} /> (<Proportion value={proportion} />,{' '}
+                <Uniqueness value={aaMutationUniqueness[mutation]} />)
+              </MutationEntry>
+            );
+          }
+        )}
       </MutationList>
       <div className='mt-4'>
         The following nucleotide mutations are present in at least 5% of the sequences of this variant
         (leading and tailing deletions are excluded):
       </div>
       <div className='ml-4'>
-        <span
-          className={commonNucMutationsSort === 'proportion' ? 'font-bold' : 'underline cursor-pointer'}
-          onClick={() => setCommonNucMutationsSort('proportion')}
-        >
-          Sort by proportion
-        </span>{' '}
-        |{' '}
-        <span
-          className={commonNucMutationsSort === 'position' ? 'font-bold' : 'underline cursor-pointer'}
-          onClick={() => setCommonNucMutationsSort('position')}
-        >
-          Sort by position
-        </span>
+        {sortOptions.map((opt, index) => (
+          <>
+            {index > 0 && <> | </>}
+            <span
+              key={opt}
+              className={commonNucMutationsSort === opt ? 'font-bold' : 'underline cursor-pointer'}
+              onClick={() => setCommonNucMutationsSort(opt)}
+            >
+              Sort by <span className={sortOptionCssClass[opt]}>{sortOptionLabels[opt]}</span>
+            </span>{' '}
+          </>
+        ))}
       </div>
       <MutationList className='list-disc'>
-        {data.data.nuc
-          .sort((a, b) => {
-            if (commonNucMutationsSort === 'proportion') {
-              return b.proportion - a.proportion;
-            } else {
-              return (
-                parseInt(a.mutation.substr(1, a.mutation.length - 2)) -
-                parseInt(b.mutation.substr(1, b.mutation.length - 2))
-              );
-            }
-          })
-          .map(({ mutation, proportion }) => {
+        {sortNucMutations(data.nuc, commonNucMutationsSort, nucMutationUniqueness).map(
+          ({ mutation, proportion }) => {
             return (
               <MutationEntry key={mutation}>
-                {mutation} ({(proportion * 100).toFixed(2)}%)
+                {mutation} (<Proportion value={proportion} />,{' '}
+                <Uniqueness value={nucMutationUniqueness[mutation]} />)
               </MutationEntry>
             );
-          })}
+          }
+        )}
       </MutationList>
     </>
   );
+};
+
+const sortAAMutations = (
+  entries: MutationProportionEntry[],
+  sortOption: SortOptions,
+  uniquenessMap: MutationUniquenessMap
+): MutationProportionEntry[] => {
+  switch (sortOption) {
+    case 'proportion':
+      return [...entries].sort((a, b) => b.proportion - a.proportion);
+    case 'position':
+      return sortListByAAMutation(entries, x => x.mutation);
+    case 'uniqueness':
+      return [...entries].sort((a, b) => {
+        if (uniquenessMap[a.mutation] === undefined && uniquenessMap[b.mutation] === undefined) {
+          return 0;
+        }
+        if (uniquenessMap[a.mutation] === undefined) {
+          return 1;
+        }
+        if (uniquenessMap[b.mutation] === undefined) {
+          return -1;
+        }
+        return uniquenessMap[b.mutation]! - uniquenessMap[a.mutation]!;
+      });
+  }
+};
+
+const sortNucMutations = (
+  entries: MutationProportionEntry[],
+  sortOption: SortOptions,
+  uniquenessMap: MutationUniquenessMap
+): MutationProportionEntry[] => {
+  return [...entries].sort((a, b) => {
+    switch (sortOption) {
+      case 'proportion':
+        return b.proportion - a.proportion;
+      case 'position':
+        return (
+          parseInt(a.mutation.substr(1, a.mutation.length - 2)) -
+          parseInt(b.mutation.substr(1, b.mutation.length - 2))
+        );
+      case 'uniqueness':
+        if (uniquenessMap[a.mutation] === undefined && uniquenessMap[b.mutation] === undefined) {
+          return 0;
+        }
+        if (uniquenessMap[a.mutation] === undefined) {
+          return 1;
+        }
+        if (uniquenessMap[b.mutation] === undefined) {
+          return -1;
+        }
+        return uniquenessMap[b.mutation]! - uniquenessMap[a.mutation]!;
+      default:
+        throw new Error('Unimplemented case');
+    }
+  });
+};
+
+const Proportion = ({ value }: { value: number }) => (
+  <span className={sortOptionCssClass['proportion']}>{(value * 100).toFixed(2)}%</span>
+);
+
+const Uniqueness = ({ value }: { value: number | undefined }) => {
+  return <span className={sortOptionCssClass['uniqueness']}>{value?.toFixed(2) ?? '...'}</span>;
+};
+
+const fetchUniquenessScore = (
+  proportionEntry: MutationProportionEntry,
+  selector: LocationDateVariantSelector,
+  variantCount: number,
+  type: SequenceType
+): Promise<number> => {
+  const mutSelector: VariantSelector =
+    type === 'aa'
+      ? { aaMutations: [proportionEntry.mutation] }
+      : { nucMutations: [proportionEntry.mutation] };
+  return fetchSamplesCount({
+    ...selector,
+    variant: mutSelector,
+  }).then(mutationCount => calculateJaccardSimilarity(variantCount, mutationCount, proportionEntry.count));
+};
+
+/**
+ *
+ * @param variantCount The number of sequences of the variant
+ * @param mutationCount The number of sequences with the mutation
+ * @param bothCount The number of sequences that belong to the variant and have the mutation
+ */
+const calculateJaccardSimilarity = (variantCount: number, mutationCount: number, bothCount: number) => {
+  return bothCount / (variantCount + mutationCount - bothCount);
 };

--- a/src/data/MutationProportionEntry.ts
+++ b/src/data/MutationProportionEntry.ts
@@ -1,4 +1,5 @@
 export type MutationProportionEntry = {
   mutation: string;
   proportion: number;
+  count: number;
 };

--- a/src/data/api-lapis.ts
+++ b/src/data/api-lapis.ts
@@ -74,6 +74,13 @@ export async function fetchCountryDateCountSamples(
   return _fetchAggSamples(selector, ['date', 'country'], signal);
 }
 
+export async function fetchSamplesCount(
+  selector: LocationDateVariantSelector,
+  signal?: AbortSignal
+): Promise<number> {
+  return _fetchAggSamples(selector, [], signal).then(entries => entries[0].count);
+}
+
 export async function fetchPangoLineageCountSamples(
   selector: LocationDateVariantSelector,
   signal?: AbortSignal

--- a/src/helpers/PromiseQueue.ts
+++ b/src/helpers/PromiseQueue.ts
@@ -1,0 +1,17 @@
+/**
+ * In a PromiseQueue, only one promise will be evaluated at the same time. If one promise gets rejected, all subsequent
+ * promises will be rejected as well.
+ */
+export class PromiseQueue {
+  private prev: Promise<any> | undefined = undefined;
+
+  async addTask<T>(task: () => Promise<T>): Promise<T> {
+    while (this.prev !== undefined) {
+      await this.prev;
+    }
+    this.prev = task();
+    const result = await this.prev;
+    this.prev = undefined;
+    return result;
+  }
+}

--- a/src/helpers/query-hook.ts
+++ b/src/helpers/query-hook.ts
@@ -1,17 +1,26 @@
 import { DependencyList, useState } from 'react';
 import { useDeepCompareEffect } from './deep-compare-hooks';
 
+export type QueryStatus<T> = {
+  isLoading: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  data: T | undefined;
+  error: any;
+};
+
 export function useQuery<T>(
   queryFunction: (signal: AbortSignal) => Promise<T>,
-  dependencies: DependencyList
-) {
+  dependencies: DependencyList,
+  useEffectFunction = useDeepCompareEffect
+): QueryStatus<T> {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isError, setIsError] = useState<boolean>(false);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
   const [data, setData] = useState<T | undefined>(undefined);
   const [error, setError] = useState<any>(undefined);
 
-  useDeepCompareEffect(() => {
+  useEffectFunction(() => {
     let isSubscribed = true;
     const controller = new AbortController();
     const signal = controller.signal;


### PR DESCRIPTION
Many thanks to @adrian-lison for the discussion on uniqueness/similarity scores and for the suggestion to use Jaccard!

This feature helps us to find mutations that are unique to a variant.

Here's an example with B.1.1.7:

![image](https://user-images.githubusercontent.com/18666552/139149869-7724c1b3-45f1-4b20-945c-59585472471a.png)
