### PR TITLE
Add a merged view with aa and nuc mutations together

### DIFF
--- a/src/data/ReferenceGenomeInfo.ts
+++ b/src/data/ReferenceGenomeInfo.ts
@@ -1,0 +1,11 @@
+export type ReferenceGenomeInfo = {
+  nuqSeq: string;
+  genes: ReferenceGenomeGeneInfo[];
+};
+
+export type ReferenceGenomeGeneInfo = {
+  name: string;
+  startPosition: number;
+  endPosition: number;
+  aaSeq: number;
+};

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -6,6 +6,7 @@ import { ArticleEntry, ArticleEntryRaw, parseArticleEntry } from './ArticleEntry
 import { PangoLineageAlias } from './PangoLineageAlias';
 import { CountryMapping } from './CountryMapping';
 import { AccountService } from '../services/AccountService';
+import { ReferenceGenomeInfo } from './ReferenceGenomeInfo';
 
 const HOST = process.env.REACT_APP_SERVER_HOST;
 
@@ -87,4 +88,13 @@ export async function fetchCountryMapping(signal?: AbortSignal): Promise<Country
     throw new Error('Error fetching country mapping');
   }
   return (await res.json()) as CountryMapping[];
+}
+
+export async function fetchReferenceGenomeInfo(signal?: AbortSignal): Promise<ReferenceGenomeInfo> {
+  const url = '/resource/reference-genome';
+  const res = await get(url, signal);
+  if (!res.ok) {
+    throw new Error('Error fetching reference genome information');
+  }
+  return (await res.json()) as ReferenceGenomeInfo;
 }

--- a/src/services/ReferenceGenomeService.ts
+++ b/src/services/ReferenceGenomeService.ts
@@ -1,0 +1,24 @@
+import { ReferenceGenomeInfo } from '../data/ReferenceGenomeInfo';
+import { fetchReferenceGenomeInfo } from '../data/api';
+
+export class ReferenceGenomeService {
+  private static data: Promise<ReferenceGenomeInfo> = ReferenceGenomeService.init();
+
+  private static async init() {
+    return fetchReferenceGenomeInfo();
+  }
+
+  /**
+   * Returns an amino acid encoded as <gene>:<position>. E.g., "S:501"
+   */
+  static async getAAOfNuc(nucPosition: number): Promise<string | undefined> {
+    const data = await ReferenceGenomeService.data;
+    for (let { name, startPosition, endPosition } of data.genes) {
+      if (nucPosition >= startPosition && nucPosition <= endPosition) {
+        const positionInGene = Math.floor((nucPosition - startPosition) / 3) + 1;
+        return `${name}:${positionInGene}`;
+      }
+    }
+    return undefined;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,12 @@ module.exports = {
         secondary: '#1269B0',
       },
     },
+    listStyleType: {
+      none: 'none',
+      disc: 'disc',
+      decimal: 'decimal',
+      circle: 'circle',
+    },
     extend: {},
   },
   variants: {


### PR DESCRIPTION
This allows us to see which nucleotide mutations belong to which amino acid mutation:

![image](https://user-images.githubusercontent.com/18666552/139436204-518924ab-53f9-476e-91b4-aa483e34c1d3.png)

Thanks to @rkdover for the idea (#288)