### PR TITLE
Add a line chart as a second visualization for the time distribution

### DIFF
--- a/src/components/NamedCard.tsx
+++ b/src/components/NamedCard.tsx
@@ -8,12 +8,19 @@ export enum NamedCardStyle {
   CONFIDENTIAL,
 }
 
+export type TabConfig = {
+  labels: string[];
+  activeTabIndex: number;
+  onNewTabSelect: (tabIndex: number) => void;
+};
+
 interface Props {
   title: string;
   toolbar?: React.ReactChild | React.ReactChild[];
   children: React.ReactChild | React.ReactChild[];
   style?: NamedCardStyle;
   description?: string;
+  tabs?: TabConfig;
 }
 
 export const Card = ({
@@ -30,6 +37,57 @@ export const Card = ({
       }`}
     >
       {children}
+    </div>
+  );
+};
+
+export const TabbedCard = ({
+  children,
+  namedCardStyle,
+  tabConfig,
+}: {
+  children: React.ReactNode;
+  namedCardStyle: NamedCardStyle;
+  tabConfig: TabConfig;
+}) => {
+  return (
+    <div className='mx-0.5 mt-1 mb-5 md:mx-3'>
+      <div
+        className={`relative shadow-lg rounded-lg bg-white p-4 border ${
+          namedCardStyle === NamedCardStyle.NORMAL ? ' border-gray-100' : 'border-red-500'
+        }`}
+      >
+        {children}
+      </div>
+      {tabConfig.labels.map((label, index) => (
+        <button
+          key={label}
+          className={`p-2 shadow-lg w-40 text-center text-sm outline-none
+            ${tabConfig.activeTabIndex === index ? 'relative bg-white cursor-default' : ''}
+          `}
+          style={
+            tabConfig.activeTabIndex === index
+              ? {
+                  borderStyle: 'solid',
+                  borderLeftWidth: '1px',
+                  borderRightWidth: '1px',
+                  borderBottomWidth: '4px',
+                  borderColor: 'lightgray',
+                  borderBottomColor: 'darkgray',
+                }
+              : {
+                  borderStyle: 'solid',
+                  borderLeftWidth: '1px',
+                  borderRightWidth: '1px',
+                  borderBottomWidth: '1px',
+                  borderColor: 'lightgray',
+                }
+          }
+          onClick={_ => tabConfig.onNewTabSelect(index)}
+        >
+          {label}
+        </button>
+      ))}
     </div>
   );
 };
@@ -62,9 +120,11 @@ export const NamedCard = ({
   children,
   style = NamedCardStyle.NORMAL,
   description,
+  tabs,
 }: Props) => {
+  const SelectedCard = tabs ? TabbedCard : Card;
   return (
-    <Card namedCardStyle={style}>
+    <SelectedCard namedCardStyle={style} tabConfig={tabs!}>
       <Title>
         <h1 className='my-0'>{title}</h1>
         {style === NamedCardStyle.CONFIDENTIAL && (
@@ -87,6 +147,6 @@ export const NamedCard = ({
       )}
       <ToolbarWrapper>{toolbar}</ToolbarWrapper>
       <ContentWrapper>{children}</ContentWrapper>
-    </Card>
+    </SelectedCard>
   );
 };

--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ButtonToolbar, Form, Modal } from 'react-bootstrap';
 import { ExportButton } from './CombinedExport/ExportButton';
 import { ExportManager, ExportManagerContext } from './CombinedExport/ExportManager';
-import { NamedCard } from './NamedCard';
+import { NamedCard, TabConfig } from './NamedCard';
 
 const host = process.env.REACT_APP_WEBSITE_HOST;
 
@@ -10,6 +10,7 @@ const host = process.env.REACT_APP_WEBSITE_HOST;
 export interface InternalProps {
   getShareUrl: () => Promise<string>;
   children: React.ReactChild | React.ReactChild[];
+  componentLabels?: string[];
 }
 
 // LayoutProps as passed by WidgetWrapper to the component responsible for Layout
@@ -17,6 +18,7 @@ export interface LayoutProps {
   title: string;
   toolbar?: React.ReactChild | React.ReactChild[];
   children: React.ReactChild | React.ReactChild[];
+  tabs?: TabConfig;
 }
 
 // ExternalProps are passed by users of Widget.ShareableComponent
@@ -61,8 +63,19 @@ export function WidgetWrapper({
   showExport = true,
   height,
   widgetLayout: WidgetLayout = NamedCard,
+  componentLabels,
 }: Props) {
   const exportManagerRef = useRef(new ExportManager());
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+
+  const childrenAsArray: (React.ReactChild | {})[] = React.Children.toArray(children);
+  const tabs: TabConfig | undefined = componentLabels
+    ? {
+        activeTabIndex,
+        labels: componentLabels,
+        onNewTabSelect: setActiveTabIndex,
+      }
+    : undefined;
 
   const [shownEmbeddingCode, setShownEmbeddingCode] = useState<string>();
 
@@ -86,8 +99,9 @@ export function WidgetWrapper({
               {toolbarChildren}
             </ButtonToolbar>
           }
+          tabs={tabs}
         >
-          <div style={height ? { height } : undefined}>{children}</div>
+          <div style={height ? { height } : undefined}>{childrenAsArray[activeTabIndex]}</div>
         </WidgetLayout>
       </ExportManagerContext.Provider>
 

--- a/src/pages/EmbedPage.tsx
+++ b/src/pages/EmbedPage.tsx
@@ -72,7 +72,7 @@ export function EmbedPage() {
         <IfFulfilled state={asyncWidgetProps}>
           {({ specific }) => (
             <ExportManagerContext.Provider value={exportManagerRef.current}>
-              <widget.Component {...specific} />
+              <widget.DefaultComponent {...specific} />
             </ExportManagerContext.Provider>
           )}
         </IfFulfilled>

--- a/src/widgets/VariantTimeDistributionBarChart.tsx
+++ b/src/widgets/VariantTimeDistributionBarChart.tsx
@@ -5,6 +5,7 @@ import { colors, TimeTick } from './common';
 import { DateCountSampleDataset } from '../data/sample/DateCountSampleDataset';
 import { fillAndFilterFromWeeklyMap } from '../helpers/fill-missing';
 import DownloadWrapper from './DownloadWrapper';
+import { VariantTimeDistributionChartProps } from './VariantTimeDistributionChartWidget';
 
 const CHART_MARGIN_RIGHT = 30;
 const CHART_MARGIN_BOTTOM = 10;
@@ -16,12 +17,7 @@ type TimeEntry = {
   quantity: number;
 };
 
-export type VariantTimeDistributionChartProps = {
-  variantSampleSet: DateCountSampleDataset;
-  wholeSampleSet: DateCountSampleDataset;
-};
-
-export const VariantTimeDistributionChart = React.memo(
+export const VariantTimeDistributionBarChart = React.memo(
   ({ variantSampleSet, wholeSampleSet }: VariantTimeDistributionChartProps): JSX.Element => {
     const data = useMemo(() => {
       const proportionByWeek = DateCountSampleDataset.proportionByWeek(
@@ -85,14 +81,14 @@ export const VariantTimeDistributionChart = React.memo(
                 : (Math.round(currentData.percent * 10) / 10).toString(),
             title: 'Proportion',
             color: colors.active,
-            helpText: 'Estimated proportion relative to all samples collected.',
+            helpText: 'Proportion relative to all samples collected',
             percent: true,
           },
           {
             value: currentData.quantity,
             title: 'Samples',
             color: colors.secondary,
-            helpText: 'Number of samples of the variant collected in this time frame.',
+            helpText: 'Number of samples of the variant collected in this time frame',
           },
         ]
       : [];
@@ -161,4 +157,4 @@ export const VariantTimeDistributionChart = React.memo(
   }
 );
 
-export default VariantTimeDistributionChart;
+export default VariantTimeDistributionBarChart;

--- a/src/widgets/VariantTimeDistributionChartWidget.ts
+++ b/src/widgets/VariantTimeDistributionChartWidget.ts
@@ -1,15 +1,19 @@
 import { Widget } from './Widget';
 import { AsyncZodQueryEncoder } from '../helpers/query-encoder';
 import * as zod from 'zod';
-import VariantTimeDistributionChart, {
-  VariantTimeDistributionChartProps,
-} from './VariantTimeDistributionChart';
+import VariantTimeDistributionBarChart from './VariantTimeDistributionBarChart';
 import {
   decodeLocationDateVariantSelector,
   encodeLocationDateVariantSelector,
   LocationDateVariantSelectorEncodedSchema,
 } from '../data/LocationDateVariantSelector';
 import { DateCountSampleDataset } from '../data/sample/DateCountSampleDataset';
+import { VariantTimeDistributionLineChart } from './VariantTimeDistributionLineChart';
+
+export type VariantTimeDistributionChartProps = {
+  variantSampleSet: DateCountSampleDataset;
+  wholeSampleSet: DateCountSampleDataset;
+};
 
 export const VariantTimeDistributionChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -28,6 +32,9 @@ export const VariantTimeDistributionChartWidget = new Widget(
       };
     }
   ),
-  VariantTimeDistributionChart,
+  [
+    { label: 'Line chart', component: VariantTimeDistributionLineChart },
+    { label: 'Bar chart', component: VariantTimeDistributionBarChart },
+  ],
   'VariantTimeDistributionChart'
 );

--- a/src/widgets/VariantTimeDistributionLineChart.tsx
+++ b/src/widgets/VariantTimeDistributionLineChart.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fillAndFilterFromDailyMap } from '../helpers/fill-missing';
+import {} from './VariantTimeDistributionBarChart';
+import { UnifiedDay } from '../helpers/date-cache';
+import { VariantTimeDistributionChartProps } from './VariantTimeDistributionChartWidget';
+import {
+  VariantTimeDistributionLineChartEntry,
+  VariantTimeDistributionLineChartInner,
+} from './VariantTimeDistributionLineChartInner';
+
+export const VariantTimeDistributionLineChart = React.memo(
+  ({ wholeSampleSet, variantSampleSet }: VariantTimeDistributionChartProps): JSX.Element => {
+    const data: Map<UnifiedDay, VariantTimeDistributionLineChartEntry> = new Map();
+    fillAndFilterFromDailyMap(
+      new Map<UnifiedDay, Omit<VariantTimeDistributionLineChartEntry, 'date'>>(),
+      {
+        sequenced: 0,
+        variantCount: 0,
+      },
+      variantSampleSet.getSelector().dateRange!.getDateRange()
+    ).forEach(({ key, value }) => data.set(key, { ...value, date: key }));
+    for (let { date, count } of wholeSampleSet.getPayload()) {
+      if (!date || !data.has(date)) {
+        continue;
+      }
+      data.get(date)!.sequenced += count;
+    }
+    for (let { date, count } of variantSampleSet.getPayload()) {
+      if (!date || !data.has(date)) {
+        continue;
+      }
+      data.get(date)!.variantCount += count;
+    }
+    return <VariantTimeDistributionLineChartInner data={new Array(...data.values())} />;
+  }
+);
+
+export default VariantTimeDistributionLineChart;

--- a/src/widgets/VariantTimeDistributionLineChartInner.tsx
+++ b/src/widgets/VariantTimeDistributionLineChartInner.tsx
@@ -1,0 +1,233 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { UnifiedDay } from '../helpers/date-cache';
+import { ChartAndMetricsWrapper, ChartWrapper, colors, TitleWrapper, Wrapper } from './common';
+import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import Metric, { MetricsWrapper } from './Metrics';
+import { getTicks } from '../helpers/ticks';
+import { calculateWilsonInterval } from '../helpers/wilson-interval';
+import dayjs from 'dayjs';
+import DownloadWrapper from './DownloadWrapper';
+import { Alert, AlertVariant } from '../helpers/ui';
+
+export type VariantTimeDistributionLineChartEntry = {
+  date: UnifiedDay;
+  sequenced: number;
+  variantCount: number;
+};
+
+export type VariantTimeDistributionLineChartProps = {
+  data: VariantTimeDistributionLineChartEntry[];
+};
+
+type PlotEntry = {
+  date: Date;
+  proportion: number;
+  proportionCI: [number, number];
+};
+
+export function formatDate(date: number) {
+  const d = new Date(date);
+  return dayjs(d).format('YYYY-MM-DD');
+}
+
+const CHART_MARGIN_RIGHT = 15;
+
+export const VariantTimeDistributionLineChartInner = React.memo(
+  ({ data }: VariantTimeDistributionLineChartProps): JSX.Element => {
+    const [active, setActive] = useState<PlotEntry | undefined>(undefined);
+
+    const {
+      plotData,
+      ticks,
+      yMax,
+    }: {
+      plotData: PlotEntry[];
+      ticks: number[];
+      yMax: number;
+    } = useMemo(() => {
+      const sortedData = [...data].sort((a, b) => (a.date.dayjs.isAfter(b.date.dayjs) ? 1 : -1));
+      const smoothedData: VariantTimeDistributionLineChartEntry[] = [];
+      for (let i = 3; i < sortedData.length - 3; i++) {
+        const window = [
+          sortedData[i - 3],
+          sortedData[i - 2],
+          sortedData[i - 1],
+          sortedData[i],
+          sortedData[i + 1],
+          sortedData[i + 2],
+          sortedData[i + 3],
+        ];
+        const sum = (accumulator: number, currentValue: number) => accumulator + currentValue;
+        smoothedData.push({
+          date: sortedData[i].date,
+          sequenced: window.map(d => d.sequenced).reduce(sum) / 7,
+          variantCount: window.map(d => d.variantCount).reduce(sum) / 7,
+        });
+      }
+
+      const plotData: PlotEntry[] = [];
+      let lastProportion = 0;
+      for (let { date, sequenced, variantCount } of smoothedData) {
+        if (date.dayjs.isAfter(dayjs())) {
+          // We don't show values for days after today
+          plotData.push({
+            date: date.dayjs.toDate(),
+            proportion: NaN,
+            proportionCI: [NaN, NaN],
+          });
+          continue;
+        }
+        if (sequenced === 0) {
+          plotData.push({
+            date: date.dayjs.toDate(),
+            // If we don't have data, we carry over the last available value as our "best guess". The CI is from 0 to 1.
+            proportion: lastProportion,
+            proportionCI: [0, 1],
+          });
+          continue;
+        }
+        lastProportion = Math.max(variantCount / sequenced, 0);
+        const wilsonInterval = calculateWilsonInterval(variantCount, sequenced);
+        // Math.max(..., 0) compensates for numerical inaccuracies which can lead to negative values.
+        plotData.push({
+          date: date.dayjs.toDate(),
+          proportion: Math.max(variantCount / sequenced, 0),
+          proportionCI: [Math.max(wilsonInterval[0], 0), Math.max(wilsonInterval[1], 0)],
+        });
+      }
+
+      const ticks = getTicks(
+        smoothedData.map(d => ({
+          date: d.date.dayjs.toDate(),
+        }))
+      );
+
+      // To avoid that big confidence intervals render the plot unreadable
+      const yMax = Math.min(
+        Math.max(...plotData.filter(d => !isNaN(d.proportion)).map(d => d.proportion * 1.5)),
+        Math.max(...plotData.filter(d => !isNaN(d.proportionCI[1])).map(d => d.proportionCI[1]))
+      );
+
+      return { plotData, ticks, yMax };
+    }, [data]);
+
+    const setDefaultActive = (plotData: PlotEntry[]) => {
+      if (plotData) {
+        const defaultActive = plotData[plotData.length - 1];
+        defaultActive !== undefined && setActive(defaultActive);
+      }
+    };
+
+    useEffect(() => {
+      setDefaultActive(plotData);
+    }, [plotData]);
+
+    const csvData = useMemo(() => {
+      return plotData.map(({ date, proportion, proportionCI }) => ({
+        date: dayjs(date).format('YYYY-MM-DD'),
+        estimatedCases: proportion.toFixed(4),
+        estimatedCasesCILower: proportionCI[0].toFixed(4),
+        estimatedCasesCIUpper: proportionCI[1].toFixed(4),
+      }));
+    }, [plotData]);
+
+    if (plotData.length === 0) {
+      return <Alert variant={AlertVariant.INFO}>We do not have enough data for this plot.</Alert>;
+    }
+
+    return (
+      <DownloadWrapper name='EstimatedCasesPlot' csvData={csvData}>
+        <Wrapper>
+          <TitleWrapper>
+            Proportion of all samples
+            {active !== undefined && (
+              <>
+                {' '}
+                between <b>{formatDate(active.date.getTime() - 3 * 24 * 60 * 60 * 1000)}</b> and{' '}
+                <b>{formatDate(active.date.getTime() + 3 * 24 * 60 * 60 * 1000)}</b>
+              </>
+            )}
+          </TitleWrapper>
+          <ChartAndMetricsWrapper>
+            <ChartWrapper>
+              <ResponsiveContainer>
+                <ComposedChart
+                  data={plotData}
+                  margin={{ top: 6, right: CHART_MARGIN_RIGHT, left: 0, bottom: 0 }}
+                >
+                  <XAxis
+                    dataKey='date'
+                    scale='time'
+                    type='number'
+                    tickFormatter={formatDate}
+                    domain={[(dataMin: any) => dataMin, () => plotData[plotData.length - 1].date.getTime()]}
+                    ticks={ticks}
+                  />
+                  <YAxis
+                    tickFormatter={tick => `${tick * 100}%`}
+                    allowDecimals={true}
+                    hide={false}
+                    width={50}
+                    domain={[0, yMax]}
+                    allowDataOverflow={true}
+                    scale='linear'
+                  />
+                  <Tooltip
+                    active={false}
+                    content={e => {
+                      if (e.active && e.payload !== undefined) {
+                        const newActive = e.payload[0].payload;
+                        if (active === undefined || active.date.getTime() !== newActive.date.getTime()) {
+                          setActive(newActive);
+                        }
+                      }
+                      return <></>;
+                    }}
+                  />
+                  <Area
+                    type='monotone'
+                    dataKey='proportionCI'
+                    fill={colors.activeSecondary}
+                    stroke='transparent'
+                    isAnimationActive={false}
+                  />
+                  <Line
+                    type='monotone'
+                    dataKey='proportion'
+                    stroke={colors.active}
+                    strokeWidth={3}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                </ComposedChart>
+              </ResponsiveContainer>
+            </ChartWrapper>
+            <MetricsWrapper>
+              <Metric
+                value={active !== undefined ? (active.proportion * 100).toFixed(1) + '%' : 'NA'}
+                title='Proportion'
+                color={colors.active}
+                helpText='Proportion relative to all samples collected (smoothed with a 7-days sliding window)'
+                percent={false}
+              />
+              <Metric
+                value={
+                  active !== undefined
+                    ? (active.proportionCI[0] * 100).toFixed(1) +
+                      '-' +
+                      (active.proportionCI[1] * 100).toFixed(1) +
+                      '%'
+                    : 'NA'
+                }
+                title='Confidence int.'
+                color={colors.secondary}
+                helpText='The 95% confidence interval'
+                percent={false}
+              />
+            </MetricsWrapper>
+          </ChartAndMetricsWrapper>
+        </Wrapper>
+      </DownloadWrapper>
+    );
+  }
+);


### PR DESCRIPTION
@corneliusroemer, what do you think? :)

![image](https://user-images.githubusercontent.com/18666552/139575899-f0699f26-5119-423c-b0c8-1bb4932d7b9f.png)


Todo

- [x] Cutoff when selecting 2021 as date range
- [x] Show y-axis ticks as percent values