### PR TITLE
Moved variant header out of loader and changed the datepicker actions

### DIFF
--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -17,8 +17,13 @@ const today = new Date();
 
 export const DateRangePicker = ({ dateRangeSelector }: Props) => {
   const { dateFrom, dateTo } = dateRangeSelector.getDateRange();
-  const [startDate, setStartDate] = useState<Date>(dateFrom ? dateFrom.dayjs.toDate() : minimumDate);
-  const [endDate, setEndDate] = useState<Date>(dateTo ? dateTo.dayjs.toDate() : today);
+  const initialStartDate = dateFrom ? dateFrom.dayjs.toDate() : minimumDate;
+  const initialEndDate = dateTo ? dateTo.dayjs.toDate() : today;
+  const prevDateFrom = globalDateCache.getDayUsingDayjs(dayjs(initialStartDate));
+  const prevDateTo = globalDateCache.getDayUsingDayjs(dayjs(initialEndDate));
+
+  const [startDate, setStartDate] = useState<Date>(initialStartDate);
+  const [endDate, setEndDate] = useState<Date>(initialEndDate);
   const starDateRef = useRef<ReactDatePicker>(null);
   const endDateRef = useRef<ReactDatePicker>(null);
   const exploreUrl = useExploreUrl();
@@ -36,10 +41,7 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
     const newDateFrom = globalDateCache.getDayUsingDayjs(dayjs(startDate));
     const newDateTo = globalDateCache.getDayUsingDayjs(dayjs(endDate));
 
-    if (
-      (dateFrom && dateFrom.string !== newDateFrom.string) ||
-      (dateTo && dateTo.string !== newDateTo.string)
-    ) {
+    if (prevDateFrom.string !== newDateFrom.string || prevDateTo.string !== newDateTo.string) {
       exploreUrl?.setDateRange(
         new FixedDateRangeSelector({
           dateFrom: newDateFrom,

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 import { HeaderDateRangeSelect } from './HeaderDateRangeSelect';
 import { useExploreUrl } from '../helpers/explore-url';
@@ -19,6 +19,8 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
   const { dateFrom, dateTo } = dateRangeSelector.getDateRange();
   const [startDate, setStartDate] = useState<Date>(dateFrom ? dateFrom.dayjs.toDate() : minimumDate);
   const [endDate, setEndDate] = useState<Date>(dateTo ? dateTo.dayjs.toDate() : today);
+  const starDateRef = useRef<ReactDatePicker>(null);
+  const endDateRef = useRef<ReactDatePicker>(null);
   const exploreUrl = useExploreUrl();
 
   useEffect(() => {
@@ -30,16 +32,25 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
     return () => {};
   }, [dateFrom, dateTo]);
 
-  const handleStartDateChange = (date: UnifiedDay) => {
+  const changeDate = () => {
     exploreUrl?.setDateRange(
-      new FixedDateRangeSelector({ dateFrom: date, dateTo: dateTo ?? globalDateCache.today() })
+      new FixedDateRangeSelector({
+        dateFrom: globalDateCache.getDayUsingDayjs(dayjs(startDate)),
+        dateTo: globalDateCache.getDayUsingDayjs(dayjs(endDate)),
+      })
     );
+  };
+
+  const handleStartDateChange = (date: UnifiedDay) => {
+    // exploreUrl?.setDateRange(
+    //   new FixedDateRangeSelector({ dateFrom: date, dateTo: dateTo ?? globalDateCache.today() })
+    // );
     setStartDate(date.dayjs.toDate());
   };
 
   const handleEndDateChange = (date: UnifiedDay) => {
-    exploreUrl?.setDateRange(new FixedDateRangeSelector({ dateFrom, dateTo: date }));
-    setStartDate(date.dayjs.toDate());
+    //exploreUrl?.setDateRange(new FixedDateRangeSelector({ dateFrom, dateTo: date }));
+    setEndDate(date.dayjs.toDate());
   };
 
   const handleStartDateRaw = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -65,12 +76,14 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
   const handleStartDateSelect = (date: Date, event: React.SyntheticEvent<any> | undefined) => {
     if (event) {
       handleStartDateChange(globalDateCache.getDayUsingDayjs(dayjs(date)));
+      starDateRef.current?.setFocus();
     }
   };
 
   const handleEndDateSelect = (date: Date, event: React.SyntheticEvent<any> | undefined) => {
     if (event) {
       handleEndDateChange(globalDateCache.getDayUsingDayjs(dayjs(date)));
+      endDateRef.current?.setFocus();
     }
   };
 
@@ -83,6 +96,7 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
         <div className='flex flex-nowrap'>
           <div className='flex flex-row items-end inline-block align-middle mr-1'>
             <ReactDatePicker
+              ref={starDateRef}
               enableTabLoop={false}
               disabledKeyboardNavigation={true}
               preventOpenOnFocus={true}
@@ -100,6 +114,8 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
               maxDate={endDate}
               calendarStartDay={1}
               useWeekdaysShort={true}
+              onBlur={changeDate}
+              shouldCloseOnSelect={false}
             />
           </div>
           <div className='flex flex-row items-center inline-block align-middle mr-1'>
@@ -107,6 +123,7 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
           </div>
           <div className=' flex-row items-end inline-block align-middle mr-1'>
             <ReactDatePicker
+              ref={endDateRef}
               enableTabLoop={false}
               disabledKeyboardNavigation={true}
               preventOpenOnFocus={true}
@@ -123,6 +140,8 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
               minDate={startDate}
               calendarStartDay={1}
               useWeekdaysShort={true}
+              onBlur={changeDate}
+              shouldCloseOnSelect={false}
             />
           </div>
         </div>

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -33,23 +33,27 @@ export const DateRangePicker = ({ dateRangeSelector }: Props) => {
   }, [dateFrom, dateTo]);
 
   const changeDate = () => {
-    exploreUrl?.setDateRange(
-      new FixedDateRangeSelector({
-        dateFrom: globalDateCache.getDayUsingDayjs(dayjs(startDate)),
-        dateTo: globalDateCache.getDayUsingDayjs(dayjs(endDate)),
-      })
-    );
+    const newDateFrom = globalDateCache.getDayUsingDayjs(dayjs(startDate));
+    const newDateTo = globalDateCache.getDayUsingDayjs(dayjs(endDate));
+
+    if (
+      (dateFrom && dateFrom.string !== newDateFrom.string) ||
+      (dateTo && dateTo.string !== newDateTo.string)
+    ) {
+      exploreUrl?.setDateRange(
+        new FixedDateRangeSelector({
+          dateFrom: newDateFrom,
+          dateTo: newDateTo,
+        })
+      );
+    }
   };
 
   const handleStartDateChange = (date: UnifiedDay) => {
-    // exploreUrl?.setDateRange(
-    //   new FixedDateRangeSelector({ dateFrom: date, dateTo: dateTo ?? globalDateCache.today() })
-    // );
     setStartDate(date.dayjs.toDate());
   };
 
   const handleEndDateChange = (date: UnifiedDay) => {
-    //exploreUrl?.setDateRange(new FixedDateRangeSelector({ dateFrom, dateTo: date }));
     setEndDate(date.dayjs.toDate());
   };
 

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -1,10 +1,8 @@
 import { mapValues } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
-import { FocusVariantHeaderControls } from '../components/FocusVariantHeaderControls';
 import Loader from '../components/Loader';
 import { NamedCard } from '../components/NamedCard';
 import { GridCell, PackedGrid } from '../components/PackedGrid';
-import { VariantHeader } from '../components/VariantHeader';
 import { VariantLineages } from '../components/VariantLineages';
 import { VariantMutations } from '../components/VariantMutations';
 import { Button, ButtonVariant, ShowMoreButton } from '../helpers/ui';
@@ -260,11 +258,6 @@ export const FocusPage = ({
   return (
     <>
       <div>
-        <VariantHeader
-          dateRange={variantDataset.selector.dateRange!} // TODO is date range always available?
-          variant={variantDataset.selector.variant!}
-          controls={<FocusVariantHeaderControls selector={variantDataset.selector} />}
-        />
         <CoreMetrics
           variantSampleSet={DateCountSampleData.fromDetailedSampleAggDataset(variantDataset)}
           wholeSampleSet={DateCountSampleData.fromDetailedSampleAggDataset(wholeDataset)}


### PR DESCRIPTION
Fix for #305 and #337

1. Moved `VariantHeader` out of `FocusPage` so that we don't reload it when data is reloaded
2. Put variant selector in state and set new value when variant dataset is changed
3. Reload variant header when another variant is selected
4. Date picker only sends new requests when user clicks out (if they select new date from calendar) or hits enter (if they input new date by typing)

@chaoran-chen @TKGZ 

https://user-images.githubusercontent.com/3387698/142632364-3d5beaa6-baa3-49ae-bb02-dd2418ec8621.mp4

