### PR TITLE
UI Headerfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Certain models and analyses require very different data than the main applicatio
 
 There is also some miscellaneous documentation about date handling ([./docs/date-cache.md](./docs/date-cache.md)), routing ([./docs/routing.md](./docs/routing.md)) and export buttons ([./docs/export.md](./docs/export.md)).
 
+## Styling
+
+Tailwind.css is used for most of the styling, though there are some custom components.
+
+### Screen Size Breakpoints
+
+`md` (medium) as defined with styled-components serves as a breakpoint between 'mobile' and 'desktop' sizes.
+
 ## Sponsors
 
 [![Vercel Sponsorship Logo](public/img/powered-by-vercel.svg)](https://vercel.com/?utm_source=cov-spectrum&utm_campaign=oss)

--- a/src/components/KnownVariantsList/KnownVariantsList.tsx
+++ b/src/components/KnownVariantsList/KnownVariantsList.tsx
@@ -133,6 +133,26 @@ export function convertKnownVariantChartData({
   }));
 }
 
+const Grid = ({
+  children,
+  isHorizontal,
+}: {
+  children: JSX.Element[] | JSX.Element;
+  isHorizontal: boolean;
+}) => {
+  return (
+    <div className={`w-full ${isHorizontal ? 'overflow-x-scroll' : ''}`}>
+      <div
+        className={`w-full grid gap-x-2 md:gap-2 ${
+          isHorizontal ? 'w-max grid-flow-col overflow-hidden auto-rows-min auto-cols-min' : 'grid-cols-2'
+        }`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
 interface Props {
   onVariantSelect: (selection: VariantSelector) => void;
   variantSelector: VariantSelector | undefined;
@@ -158,20 +178,8 @@ export const KnownVariantsList = ({
 
   const KnownVariantLoader = () => {
     const loaders = getLoadVariantCardLoaders();
-    return <Grid>{loaders}</Grid>;
+    return <Grid isHorizontal={isHorizontal}>{loaders}</Grid>;
   };
-
-  const Grid = ({ children }: { children: JSX.Element[] | JSX.Element }) => (
-    <div className={`w-full ${isHorizontal ? 'overflow-x-scroll' : ''}`}>
-      <div
-        className={`w-full grid gap-x-2 md:gap-2 ${
-          isHorizontal ? 'w-max grid-flow-col overflow-hidden auto-rows-min auto-cols-min' : 'grid-cols-2'
-        }`}
-      >
-        {children}
-      </div>
-    </div>
-  );
 
   const pangoCountDataset = useQuery(
     signal =>
@@ -242,7 +250,7 @@ export const KnownVariantsList = ({
         selected={selectedVariantList}
         onSelect={setSelectedVariantList}
       />
-      <Grid>
+      <Grid isHorizontal={isHorizontal}>
         {chartData.map(({ selector, chartData, recentProportion }) => (
           <div className={`${isHorizontal && 'h-full w-36'}`}>
             <KnownVariantCard
@@ -250,7 +258,9 @@ export const KnownVariantsList = ({
               name={formatVariantDisplayName(selector, true)}
               chartData={chartData}
               recentProportion={recentProportion}
-              onClick={() => onVariantSelect(selector)}
+              onClick={() => {
+                onVariantSelect(selector);
+              }}
               selected={
                 variantSelector &&
                 formatVariantDisplayName(variantSelector, true) === formatVariantDisplayName(selector, true)

--- a/src/components/VariantHeader.tsx
+++ b/src/components/VariantHeader.tsx
@@ -39,7 +39,7 @@ export const VariantHeader = ({ variant, titleSuffix, controls, dateRange }: Pro
   }, [variant.pangoLineage]);
 
   return (
-    <div className='ml-1 md:ml-3 w-full relative'>
+    <div className='pt-10 lg:pt-0 ml-1 md:ml-3 w-full relative'>
       <div className='absolute top-0 right-0 md:right-4'>{controls}</div>
       <div className='flex'>
         <div className='flex-grow flex flex-row flex-wrap items-end'>


### PR DESCRIPTION
Two fixes:

- Keep space on top of variant title one mobile
Before:
![CleanShot 2021-11-25 at 22 32 44](https://user-images.githubusercontent.com/36269621/143501532-0062f451-f91b-476a-9e7a-21eac5184d6a.png)
After:
![CleanShot 2021-11-25 at 22 38 09](https://user-images.githubusercontent.com/36269621/143501891-3df8828f-8584-4064-9a9a-fb7ef2cdae72.png)

- Keep scroll position for the horizontal variant previews
![CleanShot 2021-11-25 at 22 36 00](https://user-images.githubusercontent.com/36269621/143501748-da4f6aba-0191-4701-ac66-faee8e1ce5f4.gif)