### PR TITLE
Add advanced search/use variant query

### DIFF
--- a/src/components/VariantHeader.tsx
+++ b/src/components/VariantHeader.tsx
@@ -44,8 +44,14 @@ export const VariantHeader = ({ variant, titleSuffix, controls, dateRange }: Pro
       <div className='flex'>
         <div className='flex-grow flex flex-row flex-wrap items-end'>
           <h1 className='md:mr-2'>
-            {formatVariantDisplayName(variant)}
-            {label && ` (${label})`}
+            {!variant.variantQuery ? (
+              <>
+                {formatVariantDisplayName(variant)}
+                {label && ` (${label})`}
+              </>
+            ) : (
+              <>{variant.variantQuery}</>
+            )}
             {!!titleSuffix && ' - '}
             {titleSuffix}
           </h1>

--- a/src/data/VariantSelector.ts
+++ b/src/data/VariantSelector.ts
@@ -6,6 +6,7 @@ export const VariantSelectorEncodedSchema = zod.object({
   nextstrainClade: zod.string().optional(),
   aaMutations: zod.array(zod.string()).optional(),
   nucMutations: zod.array(zod.string()).optional(),
+  variantQuery: zod.string().optional(),
 });
 
 export type VariantSelector = zod.infer<typeof VariantSelectorEncodedSchema>;
@@ -25,14 +26,10 @@ export function addVariantSelectorToUrlSearchParams(selector: VariantSelector, p
   if (selector.nucMutations?.length) {
     params.set('nucMutations', selector.nucMutations.join(','));
   }
-  for (const k of ['pangoLineage', 'gisaidClade', 'nextstrainClade'] as const) {
+  for (const k of ['pangoLineage', 'gisaidClade', 'nextstrainClade', 'variantQuery'] as const) {
     const value = selector[k];
     if (value !== undefined) {
-      if (k === 'pangoLineage') {
-        params.set('pangoLineage', value);
-      } else {
-        params.set(k, value);
-      }
+      params.set(k, value);
     }
   }
 }
@@ -45,7 +42,7 @@ export function variantUrlFromSelector(selector: VariantSelector): string {
 
 export function variantIsOnlyDefinedBy(
   selector: VariantSelector,
-  field: 'pangoLineage' | 'gisaidClade' | 'nextstrainClade' | 'aaMutations' | 'nucMutations'
+  field: 'pangoLineage' | 'gisaidClade' | 'nextstrainClade' | 'aaMutations' | 'nucMutations' | 'variantQuery'
 ): boolean {
   // The field is not undefined:
   if (selector[field] === undefined) {
@@ -58,6 +55,7 @@ export function variantIsOnlyDefinedBy(
     'nextstrainClade',
     'aaMutations',
     'nucMutations',
+    'variantQuery',
   ] as const) {
     const fieldValue = selector[f];
     if (f !== field && fieldValue !== undefined) {

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -153,6 +153,7 @@ export function useExploreUrl(): ExploreUrl | undefined {
       nextstrainClade: query.get('nextstrainClade') ?? undefined,
       aaMutations: query.get('aaMutations')?.split(','),
       nucMutations: query.get('nucMutations')?.split(','),
+      variantQuery: query.get('variantQuery') ?? undefined,
     };
   }
 


### PR DESCRIPTION
Fix #347 - There is now an "Advanced search" option that allows us to specify complex queries containing and `&`, or `|` and negation `!` operators.

![image](https://user-images.githubusercontent.com/18666552/144086073-5b5a84b3-be17-4f79-858a-041a61d139c0.png)

Fix #212 - query `!B.1.617.2*`

Fix #287 - query `B.1.617.2* & (S:145H | S:222V)`

Fix #346 - query `S:484 & !S:484-`

