### PR TITLE
Select variants for comparison

### DIFF
--- a/src/components/CompareModeToggle.tsx
+++ b/src/components/CompareModeToggle.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Props {
+  handleModeChange: () => void;
+}
+
+export const CompareModeToggleSwitch = ({ handleModeChange }: Props) => {
+  return (
+    <div className='custom-control custom-switch custom-switch-lg'>
+      <input
+        type='checkbox'
+        className='custom-control-input'
+        id='customSwitches'
+        onClick={handleModeChange}
+      />
+      <label className='custom-control-label' htmlFor='customSwitches'>
+        Compare Variants
+      </label>
+    </div>
+  );
+};

--- a/src/components/CompareModeToggle.tsx
+++ b/src/components/CompareModeToggle.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
 interface Props {
+  compareMode: boolean;
   handleModeChange: () => void;
 }
 
-export const CompareModeToggleSwitch = ({ handleModeChange }: Props) => {
+export const CompareModeToggleSwitch = ({ compareMode, handleModeChange }: Props) => {
   return (
     <div className='custom-control custom-switch custom-switch-lg'>
       <input
@@ -12,6 +13,7 @@ export const CompareModeToggleSwitch = ({ handleModeChange }: Props) => {
         className='custom-control-input'
         id='customSwitches'
         onClick={handleModeChange}
+        checked={compareMode}
       />
       <label className='custom-control-label' htmlFor='customSwitches'>
         Compare Variants

--- a/src/components/KnownVariantsList/KnownVariantCard.tsx
+++ b/src/components/KnownVariantsList/KnownVariantCard.tsx
@@ -85,7 +85,9 @@ export const KnownVariantCard = ({ name, chartData, recentProportion, onClick, s
   return (
     <Card
       as={StyledCard}
-      className={`shadow-md border-0 m-0.5 hover:border-4 transition delay-20 duration-300 ease-in-out transform hover:scale-105 hover:shadow-xl w-full`}
+      className={`shadow-md m-0.5 hover:border-4 transition delay-20 duration-300 ease-in-out transform hover:scale-105 hover:shadow-xl w-full ${
+        selected ? 'border-4 border-blue-500' : ''
+      }`}
       onClick={onClick}
       selected={selected}
     >

--- a/src/components/KnownVariantsList/KnownVariantsList.tsx
+++ b/src/components/KnownVariantsList/KnownVariantsList.tsx
@@ -21,7 +21,7 @@ const KnownVariantCardLoader = (
   </div>
 );
 
-const getLoadVariantCardLoaders = (isLandingPage: boolean) => {
+const getLoadVariantCardLoaders = () => {
   let loaders = [];
   for (let i = 0; i < 12; i++) {
     loaders.push(KnownVariantCardLoader);
@@ -190,7 +190,7 @@ export const KnownVariantsList = ({
   const [chartData, setChartData] = useState<KnownVariantWithChartData[] | undefined>(undefined);
 
   const KnownVariantLoader = () => {
-    const loaders = getLoadVariantCardLoaders(isLandingPage);
+    const loaders = getLoadVariantCardLoaders();
     return (
       <Grid isHorizontal={isHorizontal} isLandingPage={isLandingPage}>
         {loaders}

--- a/src/components/KnownVariantsList/variantLists.json
+++ b/src/components/KnownVariantsList/variantLists.json
@@ -7,16 +7,13 @@
         "pangoLineage": "B.1.1.529*"
       },
       {
-        "pangoLineage": "B.1.617.2*",
-        "aaMutations": []
+        "pangoLineage": "B.1.617.2*"
       },
       {
-        "pangoLineage": "B.1.1.7*",
-        "aaMutations": []
+        "pangoLineage": "B.1.1.7*"
       },
       {
-        "pangoLineage": "B.1.351*",
-        "aaMutations": []
+        "pangoLineage": "B.1.351*"
       },
       {
         "pangoLineage": "P.1*",

--- a/src/components/VariantCompare.tsx
+++ b/src/components/VariantCompare.tsx
@@ -1,0 +1,369 @@
+import React, { useState } from 'react';
+import AsyncSelect from 'react-select/async';
+import { components, InputActionMeta, Styles } from 'react-select';
+import { isValidAAMutation } from '../helpers/aa-mutation';
+import { CSSPseudos } from 'styled-components';
+import { Button, ButtonVariant } from '../helpers/ui';
+import { PangoCountSampleData } from '../data/sample/PangoCountSampleDataset';
+import { isValidPangoLineageQuery, VariantSelector } from '../data/VariantSelector';
+import { isValidNucMutation } from '../helpers/nuc-mutation';
+import { useQuery } from '../helpers/query-hook';
+import { InternalLink } from './InternalLink';
+import { useDeepCompareEffect } from '../helpers/deep-compare-hooks';
+import Form from 'react-bootstrap/esm/Form';
+import { SamplingStrategy } from '../data/SamplingStrategy';
+
+type SearchType = 'aa-mutation' | 'nuc-mutation' | 'pango-lineage';
+
+type SearchOption = {
+  label: string;
+  value: string;
+  type: SearchType;
+};
+
+const backgroundColor: { [key in SearchType]: string } = {
+  'pango-lineage': 'rgba(29,78,207,0.1)',
+  'aa-mutation': 'rgba(4,133,27,0.1)',
+  'nuc-mutation': 'rgba(33,162,162,0.29)',
+};
+
+function mapOption(optionString: string, type: SearchType): SearchOption {
+  return {
+    label: optionString,
+    value: optionString,
+    type,
+  };
+}
+
+function variantSelectorToOptions(selector: VariantSelector): SearchOption[] {
+  const options: SearchOption[] = [];
+  if (selector.pangoLineage) {
+    options.push({ label: selector.pangoLineage, value: selector.pangoLineage, type: 'pango-lineage' });
+  }
+  if (selector.aaMutations) {
+    selector.aaMutations.forEach(m => options.push({ label: m, value: m, type: 'aa-mutation' }));
+  }
+  if (selector.nucMutations) {
+    selector.nucMutations.forEach(m => options.push({ label: m, value: m, type: 'nuc-mutation' }));
+  }
+  return options;
+}
+
+const colorStyles: Partial<Styles<any, true, any>> = {
+  control: (styles: CSSPseudos) => ({ ...styles, backgroundColor: 'white' }),
+  multiValue: (styles: CSSPseudos, { data }: { data: SearchOption }) => {
+    return {
+      ...styles,
+      backgroundColor: backgroundColor[data.type],
+    };
+  },
+};
+
+type Props = {
+  currentSelections?: VariantSelector[];
+  onVariantSelect: (selection: VariantSelector) => void;
+  isSimple: boolean;
+};
+
+export const VariantCompare = ({ onVariantSelect, currentSelections, isSimple = false }: Props) => {
+  const [selectedOptions, setSelectedOptions] = useState<SearchOption[]>([]);
+  const [inputValue, setInputValue] = useState<string>('');
+  const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false);
+  const [variantQuery, setVariantQuery] = useState('');
+  const [advancedSearch, setAdvancedSearch] = useState(false);
+
+  const pangoLineages = useQuery(
+    signal =>
+      PangoCountSampleData.fromApi(
+        { location: {}, samplingStrategy: SamplingStrategy.AllSamples },
+        signal
+      ).then(dataset => dataset.payload.filter(e => e.pangoLineage).map(e => e.pangoLineage!)),
+    []
+  );
+
+  useDeepCompareEffect(() => {
+    if (currentSelections && currentSelections.length) {
+      const currentSelection = currentSelections[currentSelections.length - 1];
+      if (currentSelection.variantQuery) {
+        setAdvancedSearch(true);
+        setVariantQuery(currentSelection.variantQuery);
+      } else {
+        setAdvancedSearch(false);
+        setSelectedOptions(variantSelectorToOptions(currentSelection));
+      }
+    }
+  }, [currentSelections]);
+
+  const suggestPangolinLineages = (query: string): string[] => {
+    return (pangoLineages.data ?? []).filter(pl => pl.toUpperCase().startsWith(query.toUpperCase()));
+  };
+
+  const suggestMutations = (query: string): string[] => {
+    // TODO Fetch all/common known mutations from the server
+    // For now, just providing a few mutations so that the auto-complete list is not entirely empty.
+    return [
+      'S:D614G',
+      'ORF1b:P314L',
+      'N:R203K',
+      'N:G204R',
+      'N:M1X',
+      'ORF1a:G3676-',
+      'ORF1a:S3675-',
+      'ORF1a:F3677-',
+      'S:N501Y',
+      'S:P681H',
+      'S:H69-',
+      'S:V70-',
+      'S:A570D',
+      'S:T716I',
+      'S:Y144-',
+      'ORF1a:T1001I',
+      'S:D1118H',
+      'ORF8:Y73C',
+      'ORF1a:A1708D',
+      'N:S235F',
+      'ORF8:Q27*',
+      'S:S982A',
+      'ORF8:R52I',
+      'N:D3L',
+      'ORF1a:I2230T',
+      'ORF3a:Q57H',
+      'ORF8:K68*',
+      'ORF1a:T265I',
+      'ORF1b:K1383R',
+      'S:L452R',
+      'S:A222V',
+      'N:D377Y',
+      'N:A220V',
+      'M:I82T',
+      'S:T478K',
+      'S:P681R',
+      'N:P199L',
+      'S:L18F',
+      'ORF3a:S26L',
+      'ORF1a:T3255I',
+      'N:R203M',
+      'S:E484K',
+      'ORF1b:P1000L',
+      'ORF7a:T120I',
+      'ORF1b:P218L',
+      'ORF1b:G662S',
+      'S:T19R',
+      'ORF7a:V82A',
+      'ORF9b:T60A',
+      'N:D63G',
+    ].filter(m => m.toUpperCase().startsWith(query.toUpperCase()));
+  };
+
+  const suggestOptions = (query: string): SearchOption[] => {
+    const onePLAlreadySelected = selectedOptions.filter(option => option.type === 'pango-lineage').length > 0;
+    const suggestions: SearchOption[] = [];
+    if (isValidAAMutation(query)) {
+      suggestions.push(mapOption(query, 'aa-mutation'));
+    } else if (isValidNucMutation(query)) {
+      suggestions.push(mapOption(query, 'nuc-mutation'));
+    } else if (!onePLAlreadySelected && isValidPangoLineageQuery(query)) {
+      suggestions.push(mapOption(query, 'pango-lineage'));
+      if (!query.endsWith('*')) {
+        suggestions.push(mapOption(query + '*', 'pango-lineage'));
+      }
+    }
+    if (!onePLAlreadySelected) {
+      suggestions.push(...suggestPangolinLineages(query).map(pl => mapOption(pl, 'pango-lineage')));
+    }
+    suggestions.push(...suggestMutations(query).map(pl => mapOption(pl, 'aa-mutation')));
+    return suggestions.slice(0, 20);
+  };
+
+  /**
+   * Handles the input change:
+   * 1) when input value contains "," or "+", call the handleCommaSeparatedInput function
+   * 2) otherwise, set the input value to the new value and keep menu window open
+   * 3) when input change action is menu-close or input-blur, close menu window
+   * @param newValue the new input value
+   * @param change the change action
+   */
+  const handleInputChange = (newValue: string, change: InputActionMeta) => {
+    if (change.action === 'input-change') {
+      // when input value has "," or "+" in the string
+      if (newValue.includes(',') || newValue.includes('+')) {
+        handleCommaSeparatedInput(newValue);
+      } else {
+        setInputValue(newValue);
+        setMenuIsOpen(true);
+      }
+    }
+
+    if (change.action === 'menu-close' || change.action === 'input-blur') {
+      setMenuIsOpen(false);
+    }
+  };
+
+  /**
+   * Handles comma-separated input value:
+   * 1) split the input value by "," and "+" to retrieve the individual query in the list
+   * 2) validate each input query by mapping to suggest options
+   * 3) add valid options to the selected options list so they transform from plain text to tags
+   * 4) max 1 pango lineage but multiple mutations allowed
+   * 5) invalid queries stay as comma-separated plain text
+   * 6) leave options menu open if there are invalid queries from the list
+   * @param inputValue comma-separated string
+   */
+  const handleCommaSeparatedInput = (inputValue: string) => {
+    const inputValues = inputValue.split(/[,+]/);
+    let newSelectedOptions: SearchOption[] = [];
+    let invalidQueries = '';
+    for (let query of inputValues) {
+      query = query.trim();
+      const suggestions = suggestOptions(query);
+      const selectedOption = suggestions.find(option => option.value.toUpperCase() === query.toUpperCase());
+      if (
+        suggestions &&
+        suggestions.length > 0 &&
+        selectedOption &&
+        !selectedOptions.find(option => option.value === selectedOption.value)
+      ) {
+        if (
+          selectedOption.type === 'aa-mutation' ||
+          selectedOption.type === 'nuc-mutation' ||
+          (selectedOption.type === 'pango-lineage' &&
+            newSelectedOptions.filter(option => option.type === 'pango-lineage').length < 1)
+        ) {
+          newSelectedOptions.push(selectedOption);
+        }
+      } else {
+        invalidQueries += query + ',';
+      }
+    }
+
+    if (newSelectedOptions.length > 0) {
+      setSelectedOptions([...selectedOptions, ...newSelectedOptions]);
+    }
+
+    // remove the last "," in the invalidQueries string
+    invalidQueries = invalidQueries.slice(0, -1);
+    setInputValue(invalidQueries);
+
+    setMenuIsOpen(invalidQueries !== '');
+  };
+
+  const promiseOptions = (inputValue: string) => {
+    // resets the options to default (where input value is '') when menu is closed
+    if (!menuIsOpen) {
+      inputValue = '';
+      setInputValue(inputValue);
+    }
+
+    return Promise.resolve(suggestOptions(inputValue));
+  };
+
+  const openMenu = () => {
+    setMenuIsOpen(!menuIsOpen);
+  };
+
+  /**
+   * This is needed because the code is converted to manually opening/closing the option menu,
+   * which overrides the default behaviour of the DropdownIndicator.
+   * @param props props of component
+   * @constructor the constructor
+   */
+  const DropdownIndicator = (props: any) => {
+    return (
+      components.DropdownIndicator && (
+        <div onClick={openMenu} style={{ display: 'flex', alignItems: 'center' }}>
+          <components.DropdownIndicator {...props} onClick={() => {}} children={props.children} />
+        </div>
+      )
+    );
+  };
+
+  return (
+    <div>
+      {!isSimple && (
+        <div className='text-sm mb-2'>
+          <p>
+            Add a variant from search bar or multi select from left panel to compare: (
+            <InternalLink path='/about#faq-search-variants'>see documentation</InternalLink>):
+          </p>
+        </div>
+      )}
+
+      <form
+        className='w-full flex flex-row items-center'
+        onSubmit={e => {
+          e.preventDefault();
+          if (!advancedSearch) {
+            let selector: VariantSelector = {};
+            for (let { type, value } of selectedOptions) {
+              if (type === 'aa-mutation') {
+                if (!selector.aaMutations) {
+                  selector.aaMutations = [];
+                }
+                selector.aaMutations.push(value);
+              } else if (type === 'nuc-mutation') {
+                if (!selector.nucMutations) {
+                  selector.nucMutations = [];
+                }
+                selector.nucMutations!.push(value);
+              } else if (type === 'pango-lineage') {
+                selector.pangoLineage = value;
+              }
+            }
+            onVariantSelect(selector);
+          } else {
+            console.log({ variantQuery });
+            onVariantSelect({ variantQuery });
+          }
+        }}
+      >
+        {!advancedSearch ? (
+          <AsyncSelect
+            className='w-full mr-2'
+            components={{ DropdownIndicator }}
+            placeholder='B.1.1.7, S:484K, C913'
+            isMulti
+            defaultOptions={suggestOptions('')}
+            loadOptions={promiseOptions}
+            onChange={(_, change) => {
+              if (change.action === 'select-option') {
+                setSelectedOptions([...selectedOptions, change.option]);
+                setInputValue('');
+                setMenuIsOpen(false);
+              } else if (change.action === 'remove-value' || change.action === 'pop-value') {
+                setSelectedOptions(selectedOptions.filter(o => o.value !== change.removedValue.value));
+              } else if (change.action === 'clear') {
+                setSelectedOptions([]);
+                setInputValue('');
+              }
+            }}
+            styles={colorStyles}
+            onInputChange={handleInputChange}
+            value={selectedOptions}
+            inputValue={inputValue}
+            menuIsOpen={menuIsOpen}
+          />
+        ) : (
+          <Form.Control
+            type='text'
+            placeholder='(B.1.1.529* | S:67V) & !C913T'
+            className='w-full mr-2'
+            value={variantQuery}
+            onChange={e => setVariantQuery(e.target.value)}
+          />
+        )}
+
+        <Button variant={ButtonVariant.PRIMARY} className='w-40'>
+          Add
+        </Button>
+      </form>
+      <div>
+        <Form.Check
+          type='checkbox'
+          label='Advanced search'
+          checked={advancedSearch}
+          onChange={_ => setAdvancedSearch(!advancedSearch)}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/VariantHeader.tsx
+++ b/src/components/VariantHeader.tsx
@@ -11,7 +11,7 @@ export interface Props {
   controls?: React.ReactChild | React.ReactChild[];
 }
 
-export const VariantHeader = ({ variant, titleSuffix, controls, dateRange }: Props) => {
+export const VariantHeader = ({ variant, titleSuffix, controls }: Props) => {
   const [resolvedFullName, setResolvedFullName] = useState<string | undefined>();
 
   const label = variantIsOnlyDefinedBy(variant, 'pangoLineage')

--- a/src/components/VariantHeader.tsx
+++ b/src/components/VariantHeader.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { PangoLineageAliasResolverService } from '../services/PangoLineageAliasResolverService';
 import { getWHOLabel, getWHOVariantType } from '../services/who-label';
-import { DateRangePicker } from './DateRangePicker';
 import { formatVariantDisplayName, variantIsOnlyDefinedBy, VariantSelector } from '../data/VariantSelector';
 import { DateRangeSelector } from '../data/DateRangeSelector';
 
@@ -56,7 +55,6 @@ export const VariantHeader = ({ variant, titleSuffix, controls, dateRange }: Pro
             {titleSuffix}
           </h1>
           {type && <h3 className='text-gray-500 sm:mr-2'>{`variant of ${type}`}</h3>}
-          {dateRange && <DateRangePicker dateRangeSelector={dateRange} />}
         </div>
       </div>
       {resolvedFullName && <h3 className=' text-gray-500'>Alias for {resolvedFullName}</h3>}

--- a/src/components/VariantsHeader.tsx
+++ b/src/components/VariantsHeader.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { formatVariantDisplayName, VariantSelector } from '../data/VariantSelector';
+import { IoIosCloseCircleOutline } from 'react-icons/io';
+
+export interface Props {
+  variants?: VariantSelector[];
+  titleSuffix?: React.ReactChild | React.ReactChild[];
+  controls?: React.ReactChild | React.ReactChild[];
+  onVariantSelect: (selection: VariantSelector) => void;
+}
+
+export const CompareVariantsHeader = ({ variants, titleSuffix, controls, onVariantSelect }: Props) => {
+  return (
+    <div className='pt-10 lg:pt-0 ml-1 my-2 md:ml-3 w-full relative'>
+      <div className='flex'>
+        <div className='flex-grow flex flex-row flex-wrap items-end'>
+          {variants && variants.length > 0 ? (
+            variants.map(variant => (
+              <button
+                className='bg-blue-500 hover:bg-blue-700 text-white rounded mr-2 py-1 px-2 inline-flex items-center'
+                onClick={() => onVariantSelect(variant)}
+              >
+                {!variant.variantQuery ? (
+                  <>{formatVariantDisplayName(variant)}</>
+                ) : (
+                  <>{variant.variantQuery}</>
+                )}
+                {!!titleSuffix && ' - '}
+                {titleSuffix}
+                <IoIosCloseCircleOutline className='ml-2 text-xl' />
+              </button>
+            ))
+          ) : (
+            <h1 className='md:mr-2'>All lineages</h1>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/VariantsHeader.tsx
+++ b/src/components/VariantsHeader.tsx
@@ -9,7 +9,7 @@ export interface Props {
   onVariantSelect: (selection: VariantSelector) => void;
 }
 
-export const CompareVariantsHeader = ({ variants, titleSuffix, controls, onVariantSelect }: Props) => {
+export const CompareVariantsHeader = ({ variants, titleSuffix, onVariantSelect }: Props) => {
   return (
     <div className='pt-10 lg:pt-0 ml-1 my-2 md:ml-3 w-full relative'>
       <div className='flex'>

--- a/src/data/VariantSelector.ts
+++ b/src/data/VariantSelector.ts
@@ -19,21 +19,25 @@ export function decodeVariantSelector(encoded: VariantSelector): VariantSelector
   return encoded;
 }
 
-export function addVariantSelectorToUrlSearchParams(selector: VariantSelector, params: URLSearchParams, index?: number) {
-  if (selector.aaMutations?.length) {
-    const aaMutationsKey = index && index > 0 ? `aaMutations${index}` : 'aaMutations'
-    params.set(aaMutationsKey, selector.aaMutations.join(','));
-  }
-  if (selector.nucMutations?.length) {
-    const nucMutationsKey = index && index > 0 ? `nucMutations${index}` : 'nucMutations'
-    params.set(nucMutationsKey, selector.nucMutations.join(','));
-  }
+export function addVariantSelectorToUrlSearchParams(
+  selector: VariantSelector,
+  params: URLSearchParams,
+  index?: number
+) {
   for (const k of ['pangoLineage', 'gisaidClade', 'nextstrainClade', 'variantQuery'] as const) {
     const value = selector[k];
     if (value !== undefined) {
       const key = index && index > 0 ? `${k}${index}` : k;
       params.set(key, value);
     }
+  }
+  if (selector.aaMutations?.length) {
+    const aaMutationsKey = index && index > 0 ? `aaMutations${index}` : 'aaMutations';
+    params.set(aaMutationsKey, selector.aaMutations.join(','));
+  }
+  if (selector.nucMutations?.length) {
+    const nucMutationsKey = index && index > 0 ? `nucMutations${index}` : 'nucMutations';
+    params.set(nucMutationsKey, selector.nucMutations.join(','));
   }
 }
 
@@ -45,36 +49,42 @@ export function variantUrlFromSelector(selector: VariantSelector): string {
 
 export function variantListUrlFromSelectors(selectors: VariantSelector[]): string {
   const params = new URLSearchParams();
-  selectors.map(function(selector, index) {
+  selectors.map(function (selector, index) {
     addVariantSelectorToUrlSearchParams(selector, params, index);
   });
   return params.toString();
 }
 
 export function decodeVariantListFromUrl(query: string): VariantSelector[] {
-    const params = query.split("&");
-    const selectors:VariantSelector[] = [];
-    params.forEach((param) => {
-      for (const k of ['aaMutations', 'nucMutations', 'pangoLineage', 'gisaidClade', 'nextstrainClade', 'variantQuery'] as const) {
-        const regex = new RegExp(k + "(.*)=(.*)")
-        const found = param.match(regex)
-        if(found && found.length >= 3){
-          const index = found[1] ? parseInt(found[1]) : 0;
-          const valueString = decodeURIComponent(found[2])
-          const value = k === 'aaMutations' || k === 'nucMutations' ? valueString.split(",") : valueString
-          let selector = selectors[index]
-          if(selector) {
-            selectors[index] = {...selector, [k]: value}
-          }else{
-            selector = {[k]: value}
-            selectors.splice(index, 0, selector);
-          }
+  const params = query.split('&');
+  const selectors: VariantSelector[] = [];
+  params.forEach(param => {
+    for (const k of [
+      'aaMutations',
+      'nucMutations',
+      'pangoLineage',
+      'gisaidClade',
+      'nextstrainClade',
+      'variantQuery',
+    ] as const) {
+      const regex = new RegExp(k + '(.*)=(.*)');
+      const found = param.match(regex);
+      if (found && found.length >= 3) {
+        const index = found[1] ? parseInt(found[1]) : 0;
+        const valueString = decodeURIComponent(found[2]);
+        const value = k === 'aaMutations' || k === 'nucMutations' ? valueString.split(',') : valueString;
+        let selector = selectors[index];
+        if (selector) {
+          selectors[index] = { ...selector, [k]: value };
+        } else {
+          selector = { [k]: value };
+          selectors.splice(index, 0, selector);
         }
       }
-    });
-    return selectors;
+    }
+  });
+  return selectors;
 }
-
 
 export function variantIsOnlyDefinedBy(
   selector: VariantSelector,

--- a/src/data/VariantSelector.ts
+++ b/src/data/VariantSelector.ts
@@ -49,7 +49,7 @@ export function variantUrlFromSelector(selector: VariantSelector): string {
 
 export function variantListUrlFromSelectors(selectors: VariantSelector[]): string {
   const params = new URLSearchParams();
-  selectors.map(function (selector, index) {
+  selectors.forEach(function (selector, index) {
     addVariantSelectorToUrlSearchParams(selector, params, index);
   });
   return params.toString();

--- a/src/helpers/app-layout.tsx
+++ b/src/helpers/app-layout.tsx
@@ -46,11 +46,11 @@ export const SplitParentWrapper = ({ children }: { children: React.ReactNode }) 
 };
 
 export const SplitExploreWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <div className='px-2 md:px-4 lg:col-span-2 2xl:col-span-1 overflow-auto'>{children}</div>;
+  return <div className='py-2 px-2 md:px-4 lg:col-span-2 2xl:col-span-1'>{children}</div>;
 };
 
 export const SplitFocusWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <div className='px-2 md:px-4 lg:col-span-3 overflow-auto'>{children}</div>;
+  return <div className='py-2 px-2 md:px-4 lg:col-span-3'>{children}</div>;
 };
 
 export const ScrollableFullContentWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/src/index.css
+++ b/src/index.css
@@ -82,3 +82,27 @@ code {
 .custom-date-filter-input:hover {
   cursor: pointer;
 }
+
+/* for custom-switch-lg */
+
+.custom-switch.custom-switch-lg .custom-control-label {
+  padding-left: 2rem;
+  padding-top: 0.3rem;
+  vertical-align: middle;
+}
+
+.custom-switch.custom-switch-lg .custom-control-label::before {
+  height: 1.8rem;
+  width: calc(3rem + 0.75rem);
+  border-radius: 4rem;
+}
+
+.custom-switch.custom-switch-lg .custom-control-label::after {
+  width: calc(2rem - 4px);
+  height: calc(1.8rem - 4px);
+  border-radius: calc(3rem - (1.8rem / 2));
+}
+
+.custom-switch.custom-switch-lg .custom-control-input:checked ~ .custom-control-label::after {
+  transform: translateX(calc(2rem - 0.25rem));
+}

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -55,7 +55,7 @@ export const ExploreFocusSplit = ({ isSmallScreen }: Props) => {
   };
   const [variantSelector, setVariantSelector] = useState<LocationDateVariantSelector>();
   const [variantSelectors, setVariantSelectors] = useState<LocationDateVariantSelector[]>();
-  const [compareMode, setCompareMode] = useState<boolean>(false);
+  const [compareMode, setCompareMode] = useState<boolean>(variants?.length ? true : false);
 
   const handleModeChange = () => {
     if (!compareMode === false) {

--- a/src/pages/ExploreFocusSplit.tsx
+++ b/src/pages/ExploreFocusSplit.tsx
@@ -215,7 +215,7 @@ export const ExploreFocusSplit = ({ isSmallScreen }: Props) => {
       <div className='flex'>
         <div className='flex-grow flex flex-row flex-wrap items-center'>
           <div className='md:mr-2'>
-            <CompareModeToggleSwitch handleModeChange={handleModeChange} />
+            <CompareModeToggleSwitch compareMode={compareMode} handleModeChange={handleModeChange} />
           </div>
           <DateRangePicker dateRangeSelector={dateRange!} />
         </div>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -25,23 +25,27 @@ const Footer = styled.footer`
 `;
 interface Props {
   onVariantSelect: (selection: VariantSelector) => void;
-  selection: VariantSelector | undefined;
+  selections?: VariantSelector[];
+  selection?: VariantSelector;
   wholeDateCountSampleDataset: DateCountSampleDataset;
   caseCountDataset: CaseCountAsyncDataset;
   wholeDataset: DetailedSampleAggDataset;
   isSmallExplore: boolean;
   isLandingPage?: boolean;
+  isCompareMode?: boolean;
 }
 
 //small explore means the explore section is small (for mobile)
 export const ExplorePage = ({
   onVariantSelect,
+  selections,
   selection,
   wholeDateCountSampleDataset,
   caseCountDataset,
   wholeDataset,
   isSmallExplore,
   isLandingPage = false,
+  isCompareMode = false,
 }: Props) => {
   const isWideLandingPage = !isSmallExplore && isLandingPage;
   const exploreUrl = useExploreUrl();
@@ -69,6 +73,8 @@ export const ExplorePage = ({
                 wholeDateCountSampleDataset={wholeDateCountSampleDataset}
                 variantSelector={selection}
                 isHorizontal={false}
+                isLandingPage={isLandingPage}
+                isCompareMode={false}
               />
             </div>
             <div className='p-2'>
@@ -105,19 +111,15 @@ export const ExplorePage = ({
         </div>
       ) : (
         <>
-          <div id='explore-search-bar' className={`${isWideLandingPage ? 'mt-8' : 'mt-4'}`}>
-            <VariantSearch
-              onVariantSelect={onVariantSelect}
-              currentSelection={selection}
-              isSimple={isSmallExplore}
-            />
-          </div>
           <div id='explore-selectors'>
             <KnownVariantsList
               onVariantSelect={onVariantSelect}
               wholeDateCountSampleDataset={wholeDateCountSampleDataset}
               variantSelector={selection}
+              variantSelectors={selections}
               isHorizontal={isSmallExplore}
+              isLandingPage={isLandingPage}
+              isCompareMode={isCompareMode}
             />
             {!isSmallExplore ? (
               <div className='w-full h-full'>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -47,7 +47,6 @@ export const ExplorePage = ({
   isLandingPage = false,
   isCompareMode = false,
 }: Props) => {
-  const isWideLandingPage = !isSmallExplore && isLandingPage;
   const exploreUrl = useExploreUrl();
   if (!exploreUrl) {
     return null;


### PR DESCRIPTION
For #309

@chaoran-chen @TKGZ 
This is roughly how it will work:

- The double scroll bars are removed
- Search bar is moved to the right in focus page
- A "Compare Variants" toggle switch is added
- Everything works as it is in Non Compare Mode
- The variant header becomes a list of buttons in compare mode, clicking on a variant button will remove it from the list.
- The KnownVariant list becomes multi selectable in "Compare Mode" (clicking = select, click again = deselect)
- The code infers from the URL whether the website should be in Compare Mode or not. (variant list length > 1 ?  compare mode)

https://user-images.githubusercontent.com/3387698/146802987-10baabb8-71df-4b3b-a6bc-693410aa07c1.mp4

But there are some questions:

1.  Why are we keeping empty array for aaMutations for all the known variants in the json file? As this empty array can interfere with object deep comparison in some places when comparing a variant with the variant list. In this draft pull request, I removed the empty aaMutations list for the first few known variants in the Editor's Choice list, this way, the comparison works for handling multiple variants in a list. 
 https://github.com/cevo-public/cov-spectrum-website/blob/434f87d3117e60d3aa59dcb4cb6e327292be94e4/src/components/KnownVariantsList/variantLists.json#L10-L15

2. Should we restrict the search bar in compare mode to only suggest variants that are not selected? Or we can add a condition to the "Add" logic to not add duplicated variants to the list.

### Screenshot:
![image](https://user-images.githubusercontent.com/3387698/146806841-d69ea2c7-4c88-405b-b4e8-588c72860413.png)

### ToDo
- [ ] Known variants json --> should keep them empty aaMutations list or not?
- [ ] Fix the focus page to display the actual comparison
- [ ] Improve the search bar logic in Compare Mode
- [ ] UI adjustments of style 