### PR TITLE
Feature/improve chen2021fitness

### DIFF
--- a/src/data/DateRange.ts
+++ b/src/data/DateRange.ts
@@ -4,3 +4,13 @@ export type DateRange = {
   dateFrom?: UnifiedDay;
   dateTo?: UnifiedDay;
 };
+
+export function isInDateRange({ dateFrom, dateTo }: DateRange, date: UnifiedDay): boolean {
+  if (dateFrom && date.dayjs.isBefore(dateFrom.dayjs, 'day')) {
+    return false;
+  }
+  if (dateTo && date.dayjs.isAfter(dateTo.dayjs, 'day')) {
+    return false;
+  }
+  return true;
+}

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -51,11 +51,12 @@ export async function fetchCurrentUserCountry(signal?: AbortSignal): Promise<Use
 
 export async function fetchCaseCounts(
   selector: LocationDateSelector,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  fields?: string[]
 ): Promise<CaseCountEntry[]> {
   const params = new URLSearchParams();
   // We are not fetching age, sex, hospitalized and died because they are currently not useful
-  params.set('fields', ['region', 'country', 'division', 'date'].join(','));
+  params.set('fields', (fields ?? ['region', 'country', 'division', 'date']).join(','));
   addLocationSelectorToUrlSearchParams(selector.location, params);
   if (selector.dateRange) {
     addDateRangeSelectorToUrlSearchParams(selector.dateRange, params);

--- a/src/helpers/selectors-from-explore-url-hook.ts
+++ b/src/helpers/selectors-from-explore-url-hook.ts
@@ -6,6 +6,7 @@ import { LocationDateSelector } from '../data/LocationDateSelector';
 export type SingleSelectorsFromExploreUrlHook = {
   ldvsSelector: LocationDateVariantSelector;
   ldsSelector: LocationDateVariantSelector;
+  lvsSelector: LocationDateVariantSelector;
   lsSelector: LocationDateVariantSelector;
   dvsSelector: LocationDateVariantSelector;
   dsSelector: LocationDateVariantSelector;
@@ -38,6 +39,14 @@ export function useSingleSelectorsFromExploreUrl(exploreUrl: ExploreUrl): Single
         samplingStrategy: exploreUrl.samplingStrategy!,
       }),
       [exploreUrl.dateRange, exploreUrl.location, exploreUrl.samplingStrategy]
+    ),
+    lvsSelector: useDeepCompareMemo(
+      () => ({
+        location: exploreUrl.location!,
+        samplingStrategy: exploreUrl.samplingStrategy!,
+        variant: firstVariant,
+      }),
+      [exploreUrl.dateRange, exploreUrl.location, exploreUrl.samplingStrategy, firstVariant]
     ),
     lsSelector: useDeepCompareMemo(
       () => ({

--- a/src/models/chen2021Fitness/Chen2021AbsolutePlot.tsx
+++ b/src/models/chen2021Fitness/Chen2021AbsolutePlot.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { TitleWrapper } from '../../widgets/common';
 import { Plot } from '../../components/Plot';
 import {
@@ -8,13 +8,18 @@ import {
   Chen2021FitnessResponse,
 } from './chen2021Fitness-types';
 import { parse } from 'json2csv';
-import { UnifiedDay } from '../../helpers/date-cache';
+import { globalDateCache, UnifiedDay } from '../../helpers/date-cache';
+import Form from 'react-bootstrap/Form';
+import { EstimatedCasesPlotEntry } from '../../widgets/EstimatedCasesChartInner';
+import { Data } from 'plotly.js';
+import dayjs from 'dayjs';
 
 interface Props {
   modelData: Chen2021FitnessResponse;
   request: Chen2021FitnessRequest;
   t0: UnifiedDay;
   changePoints?: ChangePointWithFc[];
+  estimatedCasesPlotData: EstimatedCasesPlotEntry[];
 }
 
 function daysBetween(date1: Date, date2: Date): number {
@@ -100,7 +105,17 @@ function transformChangePoints(
   }));
 }
 
-export const Chen2021AbsolutePlot = ({ modelData, request, t0, changePoints }: Props) => {
+export const Chen2021AbsolutePlot = ({
+  modelData,
+  request,
+  t0,
+  changePoints,
+  estimatedCasesPlotData,
+}: Props) => {
+  const [showNumberTotalCases, setShowNumberTotalCases] = useState(false);
+  const [showNumberVariantCases, setShowNumberVariantCases] = useState(false);
+  const [showNumberWildtypeCases, setShowNumberWildtypeCases] = useState(false);
+
   const caseNumbers = useMemo(() => {
     // Prepare and transform the change points of the reproduction number
     const changePointsWildtype = [
@@ -119,7 +134,7 @@ export const Chen2021AbsolutePlot = ({ modelData, request, t0, changePoints }: P
       ciUpper: transformChangePoints(changePointsWildtype, 'ciUpper'),
     };
 
-    // Calculate case numbers
+    // Calculate the model case numbers
     const dates = modelData.estimatedAbsoluteNumbers.t.map(date => date.dayjs.toDate());
     const wildtypeCases = calculateCases(
       t0.dayjs.add(request.config.tStart, 'day').toDate(),
@@ -150,8 +165,44 @@ export const Chen2021AbsolutePlot = ({ modelData, request, t0, changePoints }: P
       request.config.generationTime
     );
 
-    return { variantCases, variantCasesLower, variantCasesUpper, wildtypeCases };
-  }, [modelData, request, t0, changePoints]);
+    // Get the confirmed case numbers and those based on existing sequence data
+    const confirmedCasesMap = new Map<
+      UnifiedDay,
+      {
+        variant: number;
+        wildtype: number;
+      }
+    >();
+    for (let { estimatedCases: variant, estimatedWildtypeCases: wildtype, date } of estimatedCasesPlotData) {
+      confirmedCasesMap.set(globalDateCache.getDayUsingDayjs(dayjs(date)), { variant, wildtype });
+    }
+    const confirmedTotalCases = [];
+    const estimatedConfirmedVariantCases = [];
+    const estimatedConfirmedWildtypeCases = [];
+    for (let date of modelData.estimatedAbsoluteNumbers.t) {
+      let { variant, wildtype } = confirmedCasesMap.get(date) ?? { variant: NaN, wildtype: NaN };
+      if (variant + wildtype === 0) {
+        variant = NaN;
+        wildtype = NaN;
+      }
+      confirmedTotalCases.push(variant + wildtype);
+      estimatedConfirmedVariantCases.push(variant);
+      estimatedConfirmedWildtypeCases.push(wildtype);
+    }
+
+    return {
+      variantCases,
+      variantCasesLower,
+      variantCasesUpper,
+      wildtypeCases,
+      dates,
+      confirmedTotalCases,
+      estimatedConfirmedVariantCases,
+      estimatedConfirmedWildtypeCases,
+    };
+  }, [modelData, request, t0, changePoints, estimatedCasesPlotData]);
+
+  console.log(caseNumbers);
 
   if (!caseNumbers) {
     return <></>;
@@ -179,6 +230,106 @@ export const Chen2021AbsolutePlot = ({ modelData, request, t0, changePoints }: P
     document.body.removeChild(element);
   };
 
+  const plotLayers: Data[] = [
+    {
+      name: 'Wildtype',
+      type: 'scatter',
+      mode: 'lines',
+      x: caseNumbers.dates,
+      y: caseNumbers.wildtypeCases,
+      stackgroup: 'one',
+      line: {
+        color: '#1f77b4',
+      },
+      text: caseNumbers.wildtypeCases.map(n => n.toString()),
+      hovertemplate: '%{text}',
+    },
+    {
+      name: 'Variant (model)',
+      type: 'scatter',
+      mode: 'lines',
+      x: caseNumbers.dates,
+      y: caseNumbers.variantCases,
+      stackgroup: 'one',
+      line: {
+        color: '#ff7f0f',
+      },
+      text: caseNumbers.variantCases.map(n => n.toString()),
+      hovertemplate: '%{text}',
+    },
+    {
+      name: 'Variant (model, upper bound)',
+      type: 'scatter',
+      mode: 'lines',
+      line: {
+        dash: 'dot',
+        width: 4,
+        color: '#ff7f0f',
+      },
+      x: caseNumbers.dates,
+      y: arrAdd(caseNumbers.variantCasesUpper, caseNumbers.wildtypeCases),
+      text: caseNumbers.variantCasesUpper.map(n => n.toString()),
+      hovertemplate: '%{text}',
+    },
+    {
+      name: 'Variant (model, lower bound)',
+      type: 'scatter',
+      mode: 'lines',
+      line: {
+        dash: 'dot',
+        width: 4,
+        color: '#ff7f0f',
+      },
+      x: caseNumbers.dates,
+      y: arrAdd(caseNumbers.variantCasesLower, caseNumbers.wildtypeCases),
+      text: caseNumbers.variantCasesLower.map(n => n.toString()),
+      hovertemplate: '%{text}',
+    },
+  ];
+
+  if (showNumberTotalCases) {
+    plotLayers.push({
+      name: 'Total confirmed cases (data)',
+      type: 'scatter',
+      mode: 'lines',
+      x: caseNumbers.dates,
+      y: caseNumbers.confirmedTotalCases,
+      line: {
+        color: '#000000',
+      },
+      text: caseNumbers.confirmedTotalCases.map(n => n.toString()),
+      hovertemplate: '%{text}',
+    });
+  }
+  if (showNumberWildtypeCases) {
+    plotLayers.push({
+      name: 'Estimated wildtype cases (data)',
+      type: 'scatter',
+      mode: 'lines',
+      x: caseNumbers.dates,
+      y: caseNumbers.estimatedConfirmedWildtypeCases,
+      line: {
+        color: '#1b3ab5',
+      },
+      text: caseNumbers.estimatedConfirmedWildtypeCases.map(n => n.toString()),
+      hovertemplate: '%{text}',
+    });
+  }
+  if (showNumberVariantCases) {
+    plotLayers.push({
+      name: 'Estimated variant cases (data)',
+      type: 'scatter',
+      mode: 'lines',
+      x: caseNumbers.dates,
+      y: caseNumbers.estimatedConfirmedVariantCases,
+      line: {
+        color: '#ff960d',
+      },
+      text: caseNumbers.estimatedConfirmedVariantCases.map(n => n.toString()),
+      hovertemplate: '%{text}',
+    });
+  }
+
   return (
     <>
       <button onClick={downloadData} className='hover:underline outline-none'>
@@ -186,63 +337,8 @@ export const Chen2021AbsolutePlot = ({ modelData, request, t0, changePoints }: P
       </button>
       <TitleWrapper id='graph_title'>Changes in absolute case numbers through time**</TitleWrapper>
       <Plot
-        style={{ width: '100%', height: '75%' }}
-        data={[
-          {
-            name: 'Wildtype',
-            type: 'scatter',
-            mode: 'lines',
-            x: modelData.estimatedAbsoluteNumbers.t.map(date => date.dayjs.toDate()),
-            y: caseNumbers.wildtypeCases,
-            stackgroup: 'one',
-            line: {
-              color: '#1f77b4',
-            },
-            text: caseNumbers.wildtypeCases.map(n => n.toString()),
-            hovertemplate: '%{text}',
-          },
-          {
-            name: 'Variant',
-            type: 'scatter',
-            mode: 'lines',
-            x: modelData.estimatedAbsoluteNumbers.t.map(date => date.dayjs.toDate()),
-            y: caseNumbers.variantCases,
-            stackgroup: 'one',
-            line: {
-              color: '#ff7f0f',
-            },
-            text: caseNumbers.variantCases.map(n => n.toString()),
-            hovertemplate: '%{text}',
-          },
-          {
-            name: 'Variant (upper bound)',
-            type: 'scatter',
-            mode: 'lines',
-            line: {
-              dash: 'dot',
-              width: 4,
-              color: '#ff7f0f',
-            },
-            x: modelData.estimatedAbsoluteNumbers.t.map(date => date.dayjs.toDate()),
-            y: arrAdd(caseNumbers.variantCasesUpper, caseNumbers.wildtypeCases),
-            text: caseNumbers.variantCasesUpper.map(n => n.toString()),
-            hovertemplate: '%{text}',
-          },
-          {
-            name: 'Variant (lower bound)',
-            type: 'scatter',
-            mode: 'lines',
-            line: {
-              dash: 'dot',
-              width: 4,
-              color: '#ff7f0f',
-            },
-            x: modelData.estimatedAbsoluteNumbers.t.map(date => date.dayjs.toDate()),
-            y: arrAdd(caseNumbers.variantCasesLower, caseNumbers.wildtypeCases),
-            text: caseNumbers.variantCasesLower.map(n => n.toString()),
-            hovertemplate: '%{text}',
-          },
-        ]}
+        style={{ width: '100%', height: '60%' }}
+        data={plotLayers}
         layout={{
           xaxis: {
             hoverformat: '%d.%m.%Y',
@@ -267,6 +363,27 @@ export const Chen2021AbsolutePlot = ({ modelData, request, t0, changePoints }: P
         However, the above-mentioned variables change and thus the plot must be taken as a null model scenario
         rather than a projection of what will happen.
       </p>
+      <div>
+        <h3>Settings</h3>
+        <Form.Check
+          type='checkbox'
+          label='Show total number of confirmed cases from data'
+          checked={showNumberTotalCases}
+          onChange={() => setShowNumberTotalCases(!showNumberTotalCases)}
+        />
+        <Form.Check
+          type='checkbox'
+          label='Show number of estimated variant cases from data'
+          checked={showNumberVariantCases}
+          onChange={() => setShowNumberVariantCases(!showNumberVariantCases)}
+        />
+        <Form.Check
+          type='checkbox'
+          label='Show number of estimated wildtype cases from data'
+          checked={showNumberWildtypeCases}
+          onChange={() => setShowNumberWildtypeCases(!showNumberWildtypeCases)}
+        />
+      </div>
     </>
   );
 };

--- a/src/models/chen2021Fitness/Chen2021FitnessContainer.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessContainer.tsx
@@ -12,6 +12,7 @@ import dayjs from 'dayjs';
 import { useQuery } from '../../helpers/query-hook';
 import { FixedDateRangeSelector } from '../../data/DateRangeSelector';
 import Loader from '../../components/Loader';
+import { CaseCountData } from '../../data/CaseCountDataset';
 
 export type ContainerProps = {
   selector: LocationDateVariantSelector;
@@ -87,6 +88,10 @@ export const Chen2021FitnessContainer = ({ selector, defaults }: ContainerProps)
       ),
     [selector, paramData]
   );
+  const { data: caseCounts } = useQuery(
+    signal => CaseCountData.fromApi({ location: selector.location }, signal),
+    [selector]
+  );
   const { request: requestData, t0 } =
     useMemo(() => {
       if (!variantDateCounts || !wholeDateCounts) {
@@ -113,7 +118,7 @@ export const Chen2021FitnessContainer = ({ selector, defaults }: ContainerProps)
     [defaults, requestData]
   );
 
-  if (!requestData || !t0 || !variantDateCounts || !wholeDateCounts || !paramData) {
+  if (!requestData || !t0 || !variantDateCounts || !wholeDateCounts || !caseCounts || !paramData) {
     return <Loader />;
   }
 
@@ -282,6 +287,7 @@ export const Chen2021FitnessContainer = ({ selector, defaults }: ContainerProps)
         t0={t0}
         variantDateCounts={variantDateCounts}
         wholeDateCounts={wholeDateCounts}
+        caseCounts={caseCounts}
         changePoints={changePointsTransformed}
       />
       <div className='ml-6'>

--- a/src/pages/DeepChen2021FitnessPage.tsx
+++ b/src/pages/DeepChen2021FitnessPage.tsx
@@ -3,21 +3,105 @@ import { makeLayout } from '../helpers/deep-page';
 import { VariantHeader } from '../components/VariantHeader';
 import { Button } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Chen2021FitnessWidget } from '../models/chen2021Fitness/Chen2021FitnessWidget';
 import { useQuery } from '../helpers/query-hook';
 import { DateCountSampleData } from '../data/sample/DateCountSampleDataset';
 import { useSingleSelectorsFromExploreUrl } from '../helpers/selectors-from-explore-url-hook';
 import Loader from '../components/Loader';
+import { globalDateCache } from '../helpers/date-cache';
+import dayjs from 'dayjs';
+import { fetchCaseCounts } from '../data/api';
+import { FixedDateRangeSelector } from '../data/DateRangeSelector';
+import { isInDateRange } from '../data/DateRange';
 
 export const DeepChen2021FitnessPage = () => {
   const exploreUrl = useExploreUrl();
 
-  const { ldvsSelector, ldsSelector } = useSingleSelectorsFromExploreUrl(exploreUrl!);
-  const variantDateCount = useQuery(signal => DateCountSampleData.fromApi(ldvsSelector, signal), [
-    ldvsSelector,
+  const { ldvsSelector, lvsSelector, lsSelector, lSelector } = useSingleSelectorsFromExploreUrl(exploreUrl!);
+  const variantDateCount = useQuery(signal => DateCountSampleData.fromApi(lvsSelector, signal), [
+    lvsSelector,
   ]);
-  const wholeDateCount = useQuery(signal => DateCountSampleData.fromApi(ldsSelector, signal), [ldsSelector]);
+  const wholeDateCount = useQuery(signal => DateCountSampleData.fromApi(lsSelector, signal), [lsSelector]);
+
+  // Start date: day of first variant case
+  const startDate = useMemo(() => {
+    if (!variantDateCount.data || !wholeDateCount.data) {
+      return undefined;
+    }
+    // Start date: day of first variant case in the past six months
+    let startDate = globalDateCache.getDayUsingDayjs(dayjs());
+    for (let { date } of variantDateCount.data.payload) {
+      if (date && date.dayjs.isBefore(startDate.dayjs) && date.dayjs.isAfter(dayjs().subtract(6, 'month'))) {
+        startDate = date;
+      }
+    }
+    return startDate;
+  }, [variantDateCount.data, wholeDateCount.data]);
+  // startDateRange = startDate +/-3 days
+  const startDateRange = useMemo(
+    () =>
+      startDate &&
+      new FixedDateRangeSelector({
+        dateFrom: globalDateCache.getDayUsingDayjs(startDate.dayjs.subtract(3, 'day')),
+        dateTo: globalDateCache.getDayUsingDayjs(startDate.dayjs.add(3, 'day')),
+      }),
+    [startDate]
+  );
+
+  const casesInStartDateRange = useQuery(
+    signal =>
+      !startDateRange
+        ? Promise.resolve(undefined)
+        : fetchCaseCounts(
+            {
+              ...lSelector,
+              dateRange: startDateRange,
+            },
+            signal,
+            []
+          ),
+    [lSelector, startDateRange]
+  );
+
+  // Determine default values based on data
+  const defaults = useMemo(() => {
+    if (
+      !variantDateCount.data ||
+      !wholeDateCount.data ||
+      !startDate ||
+      !startDateRange ||
+      !casesInStartDateRange.data
+    ) {
+      return undefined;
+    }
+    // Sequenced samples in startDateRange
+    let variantCountInStartDateRange = 0;
+    for (let { date, count } of variantDateCount.data.payload) {
+      if (date && isInDateRange(startDateRange.getDateRange(), date)) {
+        variantCountInStartDateRange += count;
+      }
+    }
+    let wholeCountInStartDateRange = 0;
+    for (let { date, count } of wholeDateCount.data.payload) {
+      if (date && isInDateRange(startDateRange.getDateRange(), date)) {
+        wholeCountInStartDateRange += count;
+      }
+    }
+    // Initial variant cases: cases \times frequency of variant in the startDateRange
+    const numberTotalCases = Math.round(casesInStartDateRange.data[0].newCases / 7);
+    const initialVariantCases = Math.round(
+      (variantCountInStartDateRange / wholeCountInStartDateRange) * numberTotalCases
+    );
+    const initialWildtypeCases = numberTotalCases - initialVariantCases;
+    // Initial wildtype cases: 7day average of cases at time of start date (average calculated as average of cases in
+    // the 3 days before/after the day of interest)
+    return {
+      startDate,
+      initialWildtypeCases,
+      initialVariantCases,
+    };
+  }, [variantDateCount.data, wholeDateCount.data, startDate, startDateRange, casesInStartDateRange.data]);
 
   if (!exploreUrl) {
     return null;
@@ -34,8 +118,12 @@ export const DeepChen2021FitnessPage = () => {
       }
       titleSuffix='Relative growth advantage'
     />,
-    variantDateCount.data && wholeDateCount.data ? (
-      <Chen2021FitnessWidget.ShareableComponent title='Relative growth advantage' selector={ldvsSelector} />
+    defaults ? (
+      <Chen2021FitnessWidget.ShareableComponent
+        title='Relative growth advantage'
+        selector={ldvsSelector}
+        defaults={defaults}
+      />
     ) : (
       <Loader />
     )

--- a/src/widgets/EstimatedCasesChart.tsx
+++ b/src/widgets/EstimatedCasesChart.tsx
@@ -4,6 +4,7 @@ import { DateCountSampleDataset } from '../data/sample/DateCountSampleDataset';
 import { fillAndFilterFromDailyMap } from '../helpers/fill-missing';
 import Loader from '../components/Loader';
 import { CaseCountAsyncDataset } from '../data/CaseCountDataset';
+import { useMemo } from 'react';
 
 export type EstimatedCasesChartProps = {
   wholeDateCounts: DateCountSampleDataset;
@@ -16,8 +17,24 @@ export const EstimatedCasesChart = ({
   variantDateCounts,
   caseCounts,
 }: EstimatedCasesChartProps) => {
-  if (!caseCounts.payload) {
+  const data = useMemo(() => prepareData(variantDateCounts, wholeDateCounts, caseCounts), [
+    caseCounts,
+    variantDateCounts,
+    wholeDateCounts,
+  ]);
+  if (!data) {
     return <Loader />;
+  }
+  return <EstimatedCasesChartInner data={new Array(...data.values())} />;
+};
+
+export function prepareData(
+  variantDateCounts: DateCountSampleDataset,
+  wholeDateCounts: DateCountSampleDataset,
+  caseCounts: CaseCountAsyncDataset
+) {
+  if (!caseCounts.payload) {
+    return undefined;
   }
   const data: Map<UnifiedDay, EstimatedCasesTimeEntry> = new Map();
   fillAndFilterFromDailyMap(
@@ -47,5 +64,5 @@ export const EstimatedCasesChart = ({
     }
     data.get(date)!.cases += newCases;
   }
-  return <EstimatedCasesChartInner data={new Array(...data.values())} />;
-};
+  return data;
+}

--- a/src/widgets/EstimatedCasesChartInner.tsx
+++ b/src/widgets/EstimatedCasesChartInner.tsx
@@ -20,10 +20,11 @@ export type EstimatedCasesChartProps = {
   data: EstimatedCasesTimeEntry[];
 };
 
-type PlotEntry = {
+export type EstimatedCasesPlotEntry = {
   date: Date;
   estimatedCases: number;
   estimatedCasesCI: [number, number];
+  estimatedWildtypeCases: number;
 };
 
 export function formatDate(date: number) {
@@ -35,72 +36,19 @@ const CHART_MARGIN_RIGHT = 15;
 
 export const EstimatedCasesChartInner = React.memo(
   ({ data }: EstimatedCasesChartProps): JSX.Element => {
-    const [active, setActive] = useState<PlotEntry | undefined>(undefined);
+    const [active, setActive] = useState<EstimatedCasesPlotEntry | undefined>(undefined);
 
     const {
       plotData,
       ticks,
       yMax,
     }: {
-      plotData: PlotEntry[];
+      plotData: EstimatedCasesPlotEntry[];
       ticks: number[];
       yMax: number;
-    } = useMemo(() => {
-      const sortedData = [...data].sort((a, b) => (a.date.dayjs.isAfter(b.date.dayjs) ? 1 : -1));
-      const smoothedData: EstimatedCasesTimeEntry[] = [];
-      for (let i = 3; i < sortedData.length - 3; i++) {
-        const window = [
-          sortedData[i - 3],
-          sortedData[i - 2],
-          sortedData[i - 1],
-          sortedData[i],
-          sortedData[i + 1],
-          sortedData[i + 2],
-          sortedData[i + 3],
-        ];
-        const sum = (accumulator: number, currentValue: number) => accumulator + currentValue;
-        smoothedData.push({
-          date: sortedData[i].date,
-          cases: window.map(d => d.cases).reduce(sum) / 7,
-          sequenced: window.map(d => d.sequenced).reduce(sum) / 7,
-          variantCount: window.map(d => d.variantCount).reduce(sum) / 7,
-        });
-      }
+    } = useMemo(() => calculatePlotData(data), [data]);
 
-      const plotData: PlotEntry[] = [];
-      for (let { date, cases, sequenced, variantCount } of smoothedData) {
-        if (sequenced === 0) {
-          plotData.push({
-            date: date.dayjs.toDate(),
-            estimatedCases: NaN,
-            estimatedCasesCI: [NaN, NaN],
-          });
-        }
-        const wilsonInterval = calculateWilsonInterval(variantCount, sequenced);
-        // Math.max(..., 0) compensates for numerical inaccuracies which can lead to negative values.
-        plotData.push({
-          date: date.dayjs.toDate(),
-          estimatedCases: Math.max(variantCount / sequenced, 0) * cases,
-          estimatedCasesCI: [Math.max(wilsonInterval[0], 0) * cases, Math.max(wilsonInterval[1], 0) * cases],
-        });
-      }
-
-      const ticks = getTicks(
-        smoothedData.map(d => ({
-          date: d.date.dayjs.toDate(),
-        }))
-      );
-
-      // To avoid that big confidence intervals render the plot unreadable
-      const yMax = Math.min(
-        Math.max(...plotData.filter(d => !isNaN(d.estimatedCases)).map(d => d.estimatedCases * 1.5)),
-        Math.max(...plotData.filter(d => !isNaN(d.estimatedCasesCI[1])).map(d => d.estimatedCasesCI[1]))
-      );
-
-      return { plotData, ticks, yMax };
-    }, [data]);
-
-    const setDefaultActive = (plotData: PlotEntry[]) => {
+    const setDefaultActive = (plotData: EstimatedCasesPlotEntry[]) => {
       if (plotData) {
         const defaultActive = plotData[plotData.length - 1];
         defaultActive !== undefined && setActive(defaultActive);
@@ -208,3 +156,64 @@ export const EstimatedCasesChartInner = React.memo(
     );
   }
 );
+
+export function calculatePlotData(data: EstimatedCasesTimeEntry[]) {
+  const sortedData = [...data].sort((a, b) => (a.date.dayjs.isAfter(b.date.dayjs) ? 1 : -1));
+  const smoothedData: EstimatedCasesTimeEntry[] = [];
+  for (let i = 3; i < sortedData.length - 3; i++) {
+    const window = [
+      sortedData[i - 3],
+      sortedData[i - 2],
+      sortedData[i - 1],
+      sortedData[i],
+      sortedData[i + 1],
+      sortedData[i + 2],
+      sortedData[i + 3],
+    ];
+    const sum = (accumulator: number, currentValue: number) => accumulator + currentValue;
+    smoothedData.push({
+      date: sortedData[i].date,
+      cases: window.map(d => d.cases).reduce(sum) / 7,
+      sequenced: window.map(d => d.sequenced).reduce(sum) / 7,
+      variantCount: window.map(d => d.variantCount).reduce(sum) / 7,
+    });
+  }
+
+  const plotData: EstimatedCasesPlotEntry[] = [];
+  for (let { date, cases, sequenced, variantCount } of smoothedData) {
+    if (sequenced === 0) {
+      plotData.push({
+        date: date.dayjs.toDate(),
+        estimatedCases: NaN,
+        estimatedCasesCI: [NaN, NaN],
+        estimatedWildtypeCases: NaN,
+      });
+    }
+    const wilsonInterval = calculateWilsonInterval(variantCount, sequenced);
+    // Math.max(..., 0) compensates for numerical inaccuracies which can lead to negative values.
+    const estimatedCases = Math.round(Math.max(variantCount / sequenced, 0) * cases);
+    plotData.push({
+      date: date.dayjs.toDate(),
+      estimatedCases,
+      estimatedCasesCI: [
+        Math.round(Math.max(wilsonInterval[0], 0) * cases),
+        Math.round(Math.max(wilsonInterval[1], 0) * cases),
+      ],
+      estimatedWildtypeCases: Math.round(cases - estimatedCases),
+    });
+  }
+
+  const ticks = getTicks(
+    smoothedData.map(d => ({
+      date: d.date.dayjs.toDate(),
+    }))
+  );
+
+  // To avoid that big confidence intervals render the plot unreadable
+  const yMax = Math.min(
+    Math.max(...plotData.filter(d => !isNaN(d.estimatedCases)).map(d => d.estimatedCases * 1.5)),
+    Math.max(...plotData.filter(d => !isNaN(d.estimatedCasesCI[1])).map(d => d.estimatedCasesCI[1]))
+  );
+
+  return { plotData, ticks, yMax };
+}


### PR DESCRIPTION
This PR improves the chen2021fitness deep focus page.

- The default values are now (partially) derived from data.
- It is possible to plot the (true) case numbers against the model (see screenshot below).

---

![image](https://user-images.githubusercontent.com/18666552/154457465-8353a74e-5788-4554-a08f-e748d07e1933.png)
