### PR TITLE
Feature/host and qc

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,8 +64,11 @@ export const App = () => {
         {host && qc && setHostAndQc && (!isDefaultHostSelector(host) || !isDefaultQcSelector(qc)) && (
           <Alert variant={AlertVariant.WARNING}>
             <div className='flex flex-row'>
-              <FaFilter className='w-10 h-10 m-1' />
-              <div className='ml-4'>
+              <FaFilter
+                className='m-1'
+                style={{ width: '30px', minWidth: '30px', height: '30px', minHeight: '30px' }}
+              />
+              <div className='ml-4 flex-grow-1'>
                 <div className='font-weight-bold'>Advanced filters are active</div>
                 {!isDefaultHostSelector(host) && <div>Selected hosts: {host.join(', ')}</div>}
                 {!isDefaultQcSelector(qc) && <div>Sequence quality: {formatQcSelectorAsString(qc)}</div>}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { WasteWaterLocationPage } from './models/wasteWater/story/WasteWaterLoca
 import { baseLocation } from './index';
 import StoriesOverview from './stories/StoriesOverview';
 import StoryRouter from './stories/StoryRouter';
-import { defaultDateRange, defaultSamplingStrategy } from './helpers/explore-url';
+import { defaultDateRange, defaultHost, defaultSamplingStrategy, useExploreUrl } from './helpers/explore-url';
 import dayjs from 'dayjs';
 import { getCurrentLapisDataVersionDate } from './data/api-lapis';
 import { sequenceDataSource } from './helpers/sequence-data-source';
@@ -25,6 +25,9 @@ import { DeepHospitalizationDeathPage } from './pages/DeepHospitalizationDeathPa
 import { DeepWastewaterPage } from './pages/DeepWastewaterPage';
 import { DeepSequencingCoveragePage } from './pages/DeepSequencingCoveragePage';
 import { FocusPage } from './pages/FocusPage';
+import { formatQcSelectorAsString, isDefaultQcSelector } from './data/QcSelector';
+import { isDefaultHostSelector } from './data/HostSelector';
+import { FaFilter } from 'react-icons/fa';
 
 const isPreview = !!process.env.REACT_APP_IS_VERCEL_DEPLOYMENT;
 
@@ -39,12 +42,16 @@ export const App = () => {
   const { width, ref } = useResizeDetector<HTMLDivElement>();
   const isSmallScreen = width !== undefined && width < 768;
 
+  const { host, qc, setHostAndQc } = useExploreUrl() ?? {};
+
   return (
     <div className='w-full'>
+      {/* Header */}
       <div className='h-32 md:h-20'>
         <Header />
       </div>
       <div ref={ref} className='w-full'>
+        {/* Preview warning */}
         {isPreview && (
           <Alert variant={AlertVariant.WARNING}>
             <div className='text-center font-bold'>
@@ -53,6 +60,25 @@ export const App = () => {
             </div>
           </Alert>
         )}
+        {/* Warning - if advanced filters are active */}
+        {host && qc && setHostAndQc && (!isDefaultHostSelector(host) || !isDefaultQcSelector(qc)) && (
+          <Alert variant={AlertVariant.WARNING}>
+            <div className='flex flex-row'>
+              <FaFilter className='w-10 h-10 m-1' />
+              <div className='ml-4'>
+                <div className='font-weight-bold'>Advanced filters are active</div>
+                {!isDefaultHostSelector(host) && <div>Selected hosts: {host.join(', ')}</div>}
+                {!isDefaultQcSelector(qc) && <div>Sequence quality: {formatQcSelectorAsString(qc)}</div>}
+                <div className='mt-4'>
+                  <button className='underline cursor-pointer' onClick={() => setHostAndQc(defaultHost, {})}>
+                    Remove filters
+                  </button>
+                </div>
+              </div>
+            </div>
+          </Alert>
+        )}
+        {/*Main content*/}
         <Switch>
           <Route exact path='/'>
             <Redirect to={`/explore/${baseLocation}/${defaultSamplingStrategy}/${defaultDateRange}`} />

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -4,7 +4,7 @@ import { HeaderCountrySelect } from './components/HeaderCountrySelect';
 import { AccountService } from './services/AccountService';
 import { ExternalLink } from './components/ExternalLink';
 import { AiOutlineGithub, AiOutlineTwitter } from 'react-icons/ai';
-import { FaExchangeAlt } from 'react-icons/fa';
+import { FaExchangeAlt, FaFilter } from 'react-icons/fa';
 import { BsFillInfoCircleFill } from 'react-icons/bs';
 import { RiDeleteBack2Fill } from 'react-icons/ri';
 import { Button, ButtonVariant } from './helpers/ui';
@@ -13,6 +13,8 @@ import { useHistory } from 'react-router';
 import { alternativeSequenceDataSourceUrl, sequenceDataSource } from './helpers/sequence-data-source';
 import { HeaderSamplingStrategySelect } from './components/HeaderSamplingStrategySelect';
 import { encodeLocationSelectorToSingleString } from './data/LocationSelector';
+import { AlmostFullscreenModal } from './components/AlmostFullscreenModal';
+import { AdvancedFiltersPanel } from './components/AdvancedFiltersPanel';
 
 const letters = [
   { color: 'darkgray', text: 'cov' },
@@ -69,6 +71,8 @@ const BackToExplore = () => {
 };
 
 const Header = () => {
+  const [showAdvancedFilteringModal, setShowAdvancedFilteringModal] = useState(false);
+
   const loggedIn = AccountService.isLoggedIn();
   let username: string | null | undefined = null;
   if (loggedIn) {
@@ -230,6 +234,12 @@ const Header = () => {
                 <div className='flex items-center z-20 mt-2 md:mt-0'>
                   <HeaderCountrySelect />
                   <HeaderSamplingStrategySelect />
+                  <Button
+                    variant={ButtonVariant.SECONDARY}
+                    onClick={() => setShowAdvancedFilteringModal(true)}
+                  >
+                    Advanced <FaFilter className='inline' />
+                  </Button>
                   <FilterDropdown />
                 </div>
               </div>
@@ -275,6 +285,15 @@ const Header = () => {
           </div>
         </div>
       </nav>
+
+      {/* Advanced filtering modal */}
+      <AlmostFullscreenModal
+        header='Advanced filters'
+        show={showAdvancedFilteringModal}
+        handleClose={() => setShowAdvancedFilteringModal(false)}
+      >
+        <AdvancedFiltersPanel onClose={() => setShowAdvancedFilteringModal(false)} />
+      </AlmostFullscreenModal>
     </>
   );
 };

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -138,6 +138,9 @@ const Header = () => {
                     Done
                   </Button>
                 </div>
+                <button onClick={() => setShowAdvancedFilteringModal(true)}>
+                  Advanced <FaFilter className='inline' />
+                </button>
                 <a className={getDropdownButtonClasses('/stories')} href='/stories'>
                   Stories
                 </a>
@@ -237,6 +240,7 @@ const Header = () => {
                   <Button
                     variant={ButtonVariant.SECONDARY}
                     onClick={() => setShowAdvancedFilteringModal(true)}
+                    className='hidden lg:block'
                   >
                     Advanced <FaFilter className='inline' />
                   </Button>

--- a/src/components/AdvancedFiltersPanel.tsx
+++ b/src/components/AdvancedFiltersPanel.tsx
@@ -9,6 +9,7 @@ import { HostSelector } from '../data/HostSelector';
 import { HostService } from '../services/HostService';
 import { useQuery } from '../helpers/query-hook';
 import Loader from './Loader';
+import { HUMAN } from '../data/api-lapis';
 
 type Props = {
   onClose: () => void;
@@ -58,13 +59,13 @@ export const AdvancedFiltersPanel = ({ onClose }: Props) => {
             Select all
           </button>
           {' | '}
-          <button className='underline cursor-pointer ml-2' onClick={() => setHost([HostService.human])}>
+          <button className='underline cursor-pointer ml-2' onClick={() => setHost([HUMAN])}>
             Select human
           </button>
           {' | '}
           <button
             className='underline cursor-pointer ml-2'
-            onClick={() => setHost(allHosts.filter(h => h !== HostService.human))}
+            onClick={() => setHost(allHosts.filter(h => h !== HUMAN))}
           >
             Select non-human
           </button>

--- a/src/components/AdvancedFiltersPanel.tsx
+++ b/src/components/AdvancedFiltersPanel.tsx
@@ -1,0 +1,155 @@
+import { ExternalLink } from './ExternalLink';
+import { useCallback, useState } from 'react';
+import { QcSelector } from '../data/QcSelector';
+import { Utils } from '../services/Utils';
+import { Button, ButtonVariant } from '../helpers/ui';
+import { useExploreUrl } from '../helpers/explore-url';
+import Select from 'react-select';
+import { HostSelector } from '../data/HostSelector';
+import { HostService } from '../services/HostService';
+import { useQuery } from '../helpers/query-hook';
+import Loader from './Loader';
+
+type Props = {
+  onClose: () => void;
+};
+
+const fields = [
+  {
+    label: 'Overall score',
+    fromField: 'nextcladeQcOverallScoreFrom' as const,
+    toField: 'nextcladeQcOverallScoreTo' as const,
+  },
+  {
+    label: 'Missing data score',
+    fromField: 'nextcladeQcMissingDataScoreFrom' as const,
+    toField: 'nextcladeQcMissingDataScoreTo' as const,
+  },
+  {
+    label: 'Mixed sites score',
+    fromField: 'nextcladeQcMixedSitesScoreFrom' as const,
+    toField: 'nextcladeQcMixedSitesScoreTo' as const,
+  },
+  {
+    label: 'Private mutations score',
+    fromField: 'nextcladeQcPrivateMutationsScoreFrom' as const,
+    toField: 'nextcladeQcPrivateMutationsScoreTo' as const,
+  },
+  {
+    label: 'SNP clusters score',
+    fromField: 'nextcladeQcSnpClustersScoreFrom' as const,
+    toField: 'nextcladeQcSnpClustersScoreTo' as const,
+  },
+  {
+    label: 'Frame shifts score',
+    fromField: 'nextcladeQcFrameShiftsScoreFrom' as const,
+    toField: 'nextcladeQcFrameShiftsScoreTo' as const,
+  },
+  {
+    label: 'Stop codons score',
+    fromField: 'nextcladeQcStopCodonsScoreFrom' as const,
+    toField: 'nextcladeQcStopCodonsScoreTo' as const,
+  },
+];
+
+const toSelectOption = (s: string) => ({ label: s, value: s });
+
+export const AdvancedFiltersPanel = ({ onClose }: Props) => {
+  const { setHostAndQc, host: initialHost, qc: initialQc } = useExploreUrl() ?? {};
+  const [host, setHost] = useState<HostSelector>(initialHost ?? []);
+  const [qc, setQc] = useState<QcSelector>(initialQc ?? {});
+
+  const { data: allHosts } = useQuery(
+    () => HostService.allHosts.then(hs => hs.sort((a, b) => a.localeCompare(b))),
+    []
+  );
+
+  const setQcValue = useCallback(
+    (field, valueString?: string) => {
+      setQc(prev => ({
+        ...prev,
+        [field]: Utils.safeParseInt(valueString),
+      }));
+    },
+    [setQc]
+  );
+
+  const changeHostSelect = useCallback((selected: ReadonlyArray<{ label: string; value: string }>) => {
+    setHost(selected.map(option => option.value));
+  }, []);
+
+  const save = useCallback(() => {
+    if (!setHostAndQc) {
+      return;
+    }
+    setHostAndQc(host, qc);
+    onClose();
+  }, [host, qc, setHostAndQc, onClose]);
+
+  return (
+    <>
+      {/* Hosts */}
+      <h2>Hosts</h2>
+      {allHosts ? (
+        <>
+          <button className='underline cursor-pointer mr-2' onClick={() => setHost(allHosts)}>
+            Select all
+          </button>{' '}
+          |{' '}
+          <button className='underline cursor-pointer ml-2' onClick={() => setHost([HostService.human])}>
+            Select default
+          </button>{' '}
+          |{' '}
+          <button className='underline cursor-pointer ml-2' onClick={() => setHost([])}>
+            Select none
+          </button>
+          <Select
+            isMulti
+            closeMenuOnSelect={false}
+            options={allHosts.map(toSelectOption)}
+            value={host.map(toSelectOption)}
+            placeholder='Select hosts...'
+            onChange={changeHostSelect}
+            className='mt-2'
+          />
+          <div className='mt-2'>By default, only sequences obtained from human hosts are used.</div>
+        </>
+      ) : (
+        <div style={{ height: 200 }}>
+          <Loader />
+        </div>
+      )}
+      {/* Sequence quality */}
+      <h2>Sequence quality</h2>
+      Here, you can filter the sequences by the QC (quality control) metrics calculated by{' '}
+      <ExternalLink url='https://clades.nextstrain.org/'>Nextclade</ExternalLink>. In general, 0 to 29 is
+      considered as good, 30 to 99 is mediocre, and over 100 is bad. For more information, please check out{' '}
+      <ExternalLink url='https://docs.nextstrain.org/projects/nextclade/en/latest/user/algorithm/07-quality-control.html'>
+        Nextclade's documentation
+      </ExternalLink>
+      .
+      {fields.map(({ label, fromField, toField }) => (
+        <div className='py-2' key={label}>
+          {label}:{' '}
+          <input
+            className='border w-24'
+            type='number'
+            value={qc[fromField] ?? ''}
+            onChange={e => setQcValue(fromField, e.target.value)}
+          />{' '}
+          -{' '}
+          <input
+            className='border w-24'
+            type='number'
+            value={qc[toField] ?? ''}
+            onChange={e => setQcValue(toField, e.target.value)}
+          />
+        </div>
+      ))}
+      {/* Save */}
+      <Button variant={ButtonVariant.SECONDARY} className='w-full mt-2' onClick={save}>
+        Save
+      </Button>
+    </>
+  );
+};

--- a/src/components/AdvancedFiltersPanel.tsx
+++ b/src/components/AdvancedFiltersPanel.tsx
@@ -94,14 +94,17 @@ export const AdvancedFiltersPanel = ({ onClose }: Props) => {
         <>
           <button className='underline cursor-pointer mr-2' onClick={() => setHost(allHosts)}>
             Select all
-          </button>{' '}
-          |{' '}
+          </button>
+          {' | '}
           <button className='underline cursor-pointer ml-2' onClick={() => setHost([HostService.human])}>
-            Select default
-          </button>{' '}
-          |{' '}
-          <button className='underline cursor-pointer ml-2' onClick={() => setHost([])}>
-            Select none
+            Select human
+          </button>
+          {' | '}
+          <button
+            className='underline cursor-pointer ml-2'
+            onClick={() => setHost(allHosts.filter(h => h !== HostService.human))}
+          >
+            Select non-human
           </button>
           <Select
             isMulti
@@ -128,6 +131,32 @@ export const AdvancedFiltersPanel = ({ onClose }: Props) => {
         Nextclade's documentation
       </ExternalLink>
       .
+      <div>
+        <button className='underline cursor-pointer mr-2' onClick={() => setQc({})}>
+          Select all
+        </button>
+        {' | '}
+        <button
+          className='underline cursor-pointer mr-2'
+          onClick={() => setQc({ nextcladeQcOverallScoreTo: 29 })}
+        >
+          Select good
+        </button>
+        {' | '}
+        <button
+          className='underline cursor-pointer mr-2'
+          onClick={() => setQc({ nextcladeQcOverallScoreTo: 99 })}
+        >
+          Select good and mediocre
+        </button>
+        {' | '}
+        <button
+          className='underline cursor-pointer mr-2'
+          onClick={() => setQc({ nextcladeQcOverallScoreFrom: 100 })}
+        >
+          Select only bad
+        </button>
+      </div>
       {fields.map(({ label, fromField, toField }) => (
         <div className='py-2' key={label}>
           {label}:{' '}

--- a/src/components/AdvancedFiltersPanel.tsx
+++ b/src/components/AdvancedFiltersPanel.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink } from './ExternalLink';
 import { useCallback, useState } from 'react';
-import { QcSelector } from '../data/QcSelector';
+import { qcFieldsAndLabels, QcSelector } from '../data/QcSelector';
 import { Utils } from '../services/Utils';
 import { Button, ButtonVariant } from '../helpers/ui';
 import { useExploreUrl } from '../helpers/explore-url';
@@ -13,44 +13,6 @@ import Loader from './Loader';
 type Props = {
   onClose: () => void;
 };
-
-const fields = [
-  {
-    label: 'Overall score',
-    fromField: 'nextcladeQcOverallScoreFrom' as const,
-    toField: 'nextcladeQcOverallScoreTo' as const,
-  },
-  {
-    label: 'Missing data score',
-    fromField: 'nextcladeQcMissingDataScoreFrom' as const,
-    toField: 'nextcladeQcMissingDataScoreTo' as const,
-  },
-  {
-    label: 'Mixed sites score',
-    fromField: 'nextcladeQcMixedSitesScoreFrom' as const,
-    toField: 'nextcladeQcMixedSitesScoreTo' as const,
-  },
-  {
-    label: 'Private mutations score',
-    fromField: 'nextcladeQcPrivateMutationsScoreFrom' as const,
-    toField: 'nextcladeQcPrivateMutationsScoreTo' as const,
-  },
-  {
-    label: 'SNP clusters score',
-    fromField: 'nextcladeQcSnpClustersScoreFrom' as const,
-    toField: 'nextcladeQcSnpClustersScoreTo' as const,
-  },
-  {
-    label: 'Frame shifts score',
-    fromField: 'nextcladeQcFrameShiftsScoreFrom' as const,
-    toField: 'nextcladeQcFrameShiftsScoreTo' as const,
-  },
-  {
-    label: 'Stop codons score',
-    fromField: 'nextcladeQcStopCodonsScoreFrom' as const,
-    toField: 'nextcladeQcStopCodonsScoreTo' as const,
-  },
-];
 
 const toSelectOption = (s: string) => ({ label: s, value: s });
 
@@ -157,7 +119,7 @@ export const AdvancedFiltersPanel = ({ onClose }: Props) => {
           Select only bad
         </button>
       </div>
-      {fields.map(({ label, fromField, toField }) => (
+      {qcFieldsAndLabels.map(({ label, fromField, toField }) => (
         <div className='py-2' key={label}>
           {label}:{' '}
           <input

--- a/src/components/FocusVariantHeaderControls.tsx
+++ b/src/components/FocusVariantHeaderControls.tsx
@@ -7,7 +7,6 @@ import { OutbreakInfoIntegration } from '../services/external-integrations/Outbr
 import { WikipediaIntegration } from '../services/external-integrations/WikipediaIntegration';
 import { CoVariantsIntegration } from '../services/external-integrations/CoVariantsIntegration';
 import { useState } from 'react';
-import { LocationDateVariantSelector } from '../data/LocationDateVariantSelector';
 import { FaDownload } from 'react-icons/fa';
 import { UsherIntegration } from '../services/external-integrations/UsherIntegration';
 import { sequenceDataSource } from '../helpers/sequence-data-source';
@@ -18,9 +17,10 @@ import { useDeepCompareMemo } from '../helpers/deep-compare-hooks';
 import { useAsync } from 'react-async';
 import { OrderAndLimitConfig } from '../data/OrderAndLimitConfig';
 import { NextcladeIntegration } from '../services/external-integrations/NextcladeIntegration';
+import { LapisSelector } from '../data/LapisSelector';
 
 export interface Props {
-  selector: LocationDateVariantSelector;
+  selector: LapisSelector;
 }
 
 const integrations: Integration[] = [

--- a/src/components/KnownVariantsList/KnownVariantsList.tsx
+++ b/src/components/KnownVariantsList/KnownVariantsList.tsx
@@ -7,12 +7,13 @@ import { PangoCountSampleData } from '../../data/sample/PangoCountSampleDataset'
 import { SpecialDateRangeSelector } from '../../data/DateRangeSelector';
 import { PangoCountSampleEntry } from '../../data/sample/PangoCountSampleEntry';
 import { formatVariantDisplayName, VariantSelector } from '../../data/VariantSelector';
-import { LocationDateVariantSelector } from '../../data/LocationDateVariantSelector';
 import { globalDateCache } from '../../helpers/date-cache';
 import assert from 'assert';
 import dayjs from 'dayjs';
 import { useQuery } from '../../helpers/query-hook';
 import { AnalysisMode } from '../../data/AnalysisMode';
+import { HostAndQcSelector } from '../../data/HostAndQcSelector';
+import { LapisSelector } from '../../data/LapisSelector';
 
 const VARIANT_LISTS: VariantList[] = _VARIANT_LISTS;
 
@@ -163,6 +164,7 @@ interface Props {
   onVariantSelect: (selection: VariantSelector[], analysisMode?: AnalysisMode) => void;
   variantSelector: VariantSelector | VariantSelector[] | undefined;
   wholeDateCountSampleDataset: DateCountSampleDataset;
+  hostAndQc: HostAndQcSelector;
   isHorizontal: boolean;
   isLandingPage: boolean;
 }
@@ -177,6 +179,7 @@ interface Props {
 export const KnownVariantsList = ({
   onVariantSelect,
   variantSelector,
+  hostAndQc,
   wholeDateCountSampleDataset,
   isHorizontal = false,
   isLandingPage,
@@ -200,6 +203,7 @@ export const KnownVariantsList = ({
           location: wholeDateCountSampleDataset.selector.location,
           dateRange: new SpecialDateRangeSelector('Past3M'),
           samplingStrategy: wholeDateCountSampleDataset.selector.samplingStrategy,
+          ...hostAndQc,
         },
         signal
       ),
@@ -223,19 +227,23 @@ export const KnownVariantsList = ({
       return;
     }
 
-    const createSelector = (variantSelector: VariantSelector): LocationDateVariantSelector => {
+    const createSelector = (
+      variantSelector: VariantSelector,
+      hostAndQc: HostAndQcSelector
+    ): LapisSelector => {
       return {
         location: wholeDateCountSampleDataset.selector.location,
         dateRange: new SpecialDateRangeSelector('Past3M'),
         variant: variantSelector,
         samplingStrategy: wholeDateCountSampleDataset.selector.samplingStrategy,
+        ...hostAndQc,
       };
     };
 
     async function fetchAll(knownVariantSelectors: VariantSelector[]) {
       return await Promise.all(
         knownVariantSelectors.map(vs => {
-          const selector = createSelector(vs);
+          const selector = createSelector(vs, hostAndQc);
           return DateCountSampleData.fromApi(selector);
         })
       );
@@ -247,7 +255,7 @@ export const KnownVariantsList = ({
       });
       setChartData(_chartData);
     });
-  }, [knownVariantSelectors, wholeDateCountSampleDataset]);
+  }, [knownVariantSelectors, wholeDateCountSampleDataset, hostAndQc]);
 
   if (!chartData) {
     return (

--- a/src/components/KnownVariantsList/KnownVariantsList.tsx
+++ b/src/components/KnownVariantsList/KnownVariantsList.tsx
@@ -12,6 +12,7 @@ import { globalDateCache } from '../../helpers/date-cache';
 import assert from 'assert';
 import dayjs from 'dayjs';
 import { useQuery } from '../../helpers/query-hook';
+import { AnalysisMode } from '../../data/AnalysisMode';
 
 const VARIANT_LISTS: VariantList[] = _VARIANT_LISTS;
 
@@ -159,7 +160,7 @@ const Grid = ({
 };
 
 interface Props {
-  onVariantSelect: (selection: VariantSelector) => void;
+  onVariantSelect: (selection: VariantSelector[], analysisMode?: AnalysisMode) => void;
   variantSelector: VariantSelector | VariantSelector[] | undefined;
   wholeDateCountSampleDataset: DateCountSampleDataset;
   isHorizontal: boolean;
@@ -272,7 +273,7 @@ export const KnownVariantsList = ({
               chartData={chartData}
               recentProportion={recentProportion}
               onClick={() => {
-                onVariantSelect(selector);
+                onVariantSelect([selector], AnalysisMode.Single);
               }}
               selected={variantSelector && isSelected(selector, variantSelector)}
             />

--- a/src/components/VariantHosts.tsx
+++ b/src/components/VariantHosts.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { LoaderSmall } from './Loader';
+import { HostCountSampleData } from '../data/sample/HostCountSampleDataset';
+import { LapisSelector } from '../data/LapisSelector';
+
+export interface Props {
+  selector: LapisSelector;
+}
+
+const LineageEntry = styled.li`
+  width: 250px;
+`;
+
+export const VariantHosts = ({ selector }: Props) => {
+  const [data, setData] = useState<
+    | {
+        host: string | null;
+        proportion: number;
+      }[]
+    | undefined
+  >(undefined);
+
+  useEffect(() => {
+    HostCountSampleData.fromApi(selector).then(hostCountDataset => {
+      const total = hostCountDataset.payload.reduce((prev, curr) => prev + curr.count, 0);
+      const proportions = hostCountDataset.payload.map(e => ({
+        host: e.host,
+        proportion: e.count / total,
+      }));
+      setData(proportions);
+    });
+  }, [selector]);
+
+  return (
+    <>
+      <div>Sequences of this variant were found in the following hosts:</div>
+
+      {!data ? (
+        <div className='h-20 w-full flex items-center'>
+          <LoaderSmall />
+        </div>
+      ) : (
+        <ul className='list-disc flex flex-wrap max-h-24 overflow-y-auto '>
+          {data
+            .sort((a, b) => b.proportion - a.proportion)
+            .map(({ host, proportion }) => {
+              const label = host || 'Unknown';
+              return (
+                <LineageEntry key={label}>
+                  {label} ({(proportion * 100).toFixed(2)}%)
+                </LineageEntry>
+              );
+            })}
+        </ul>
+      )}
+    </>
+  );
+};

--- a/src/components/VariantLineages.tsx
+++ b/src/components/VariantLineages.tsx
@@ -7,7 +7,7 @@ import { VariantSelector } from '../data/VariantSelector';
 
 export interface Props {
   selector: LocationDateVariantSelector;
-  onVariantSelect: (selection: VariantSelector) => void;
+  onVariantSelect: (selection: VariantSelector[]) => void;
 }
 
 const LineageEntry = styled.li`
@@ -53,7 +53,7 @@ export const VariantLineages = ({ selector, onVariantSelect }: Props) => {
                   {pangoLineage ? (
                     <button
                       className='underline outline-none'
-                      onClick={() => onVariantSelect({ pangoLineage })}
+                      onClick={() => onVariantSelect([{ pangoLineage }])}
                     >
                       {pangoLineage}
                     </button>

--- a/src/components/VariantLineages.tsx
+++ b/src/components/VariantLineages.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { LoaderSmall } from './Loader';
-import { LocationDateVariantSelector } from '../data/LocationDateVariantSelector';
 import { PangoCountSampleData } from '../data/sample/PangoCountSampleDataset';
 import { VariantSelector } from '../data/VariantSelector';
+import { LapisSelector } from '../data/LapisSelector';
 
 export interface Props {
-  selector: LocationDateVariantSelector;
+  selector: LapisSelector;
   onVariantSelect: (selection: VariantSelector[]) => void;
 }
 

--- a/src/components/VariantMutationComparison.tsx
+++ b/src/components/VariantMutationComparison.tsx
@@ -1,4 +1,3 @@
-import { LocationDateVariantSelector } from '../data/LocationDateVariantSelector';
 import { useQuery } from '../helpers/query-hook';
 import { MutationProportionData } from '../data/MutationProportionDataset';
 import Loader from './Loader';
@@ -11,9 +10,10 @@ import ReactTooltip from 'react-tooltip';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import Slider from 'rc-slider';
 import { sortAAMutationList } from '../helpers/aa-mutation';
+import { LapisSelector } from '../data/LapisSelector';
 
 export interface Props {
-  selectors: LocationDateVariantSelector[];
+  selectors: LapisSelector[];
 }
 
 export const VariantMutationComparison = ({ selectors }: Props) => {

--- a/src/components/VariantMutations.tsx
+++ b/src/components/VariantMutations.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { MutationName } from './MutationName';
 import { decodeAAMutation, sortListByAAMutation } from '../helpers/aa-mutation';
-import { LocationDateVariantSelector } from '../data/LocationDateVariantSelector';
 import { MutationProportionData } from '../data/MutationProportionDataset';
 import Loader from './Loader';
 import { useQuery } from '../helpers/query-hook';
@@ -13,9 +12,10 @@ import { VariantSelector } from '../data/VariantSelector';
 import { PromiseQueue } from '../helpers/PromiseQueue';
 import { ReferenceGenomeService } from '../services/ReferenceGenomeService';
 import NumericInput from 'react-numeric-input';
+import { LapisSelector } from '../data/LapisSelector';
 
 export interface Props {
-  selector: LocationDateVariantSelector;
+  selector: LapisSelector;
 }
 
 const MutationList = styled.ul`
@@ -397,7 +397,7 @@ const Uniqueness = ({ value }: { value: number | undefined }) => {
 
 const fetchUniquenessScore = (
   proportionEntry: MutationProportionEntry,
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   variantCount: number,
   type: SequenceType
 ): Promise<number> => {

--- a/src/components/VariantSearchField.tsx
+++ b/src/components/VariantSearchField.tsx
@@ -76,7 +76,7 @@ export const VariantSearchField = ({ onVariantSelect, currentSelection, triggerS
   const pangoLineages = useQuery(
     signal =>
       PangoCountSampleData.fromApi(
-        { location: {}, samplingStrategy: SamplingStrategy.AllSamples },
+        { location: {}, samplingStrategy: SamplingStrategy.AllSamples, host: undefined, qc: {} },
         signal
       ).then(dataset => dataset.payload.filter(e => e.pangoLineage).map(e => e.pangoLineage!)),
     []

--- a/src/components/VariantSearchField.tsx
+++ b/src/components/VariantSearchField.tsx
@@ -8,7 +8,7 @@ import { isValidPangoLineageQuery, VariantSelector } from '../data/VariantSelect
 import { isValidNucMutation } from '../helpers/nuc-mutation';
 import { useQuery } from '../helpers/query-hook';
 import { useDeepCompareEffect } from '../helpers/deep-compare-hooks';
-import Form from 'react-bootstrap/esm/Form';
+import Form from 'react-bootstrap/Form';
 import { SamplingStrategy } from '../data/SamplingStrategy';
 
 type SearchType = 'aa-mutation' | 'nuc-mutation' | 'pango-lineage';

--- a/src/data/HostAndQcSelector.ts
+++ b/src/data/HostAndQcSelector.ts
@@ -1,0 +1,16 @@
+import { HostSelector } from './HostSelector';
+import { QcSelector } from './QcSelector';
+import { defaultHost } from '../helpers/explore-url';
+
+export type HostAndQcSelector = {
+  host: HostSelector | undefined;
+  qc: QcSelector;
+};
+
+export function addDefaultHostAndQc<T extends object>(obj: T): T & HostAndQcSelector {
+  return {
+    ...obj,
+    host: defaultHost,
+    qc: {},
+  };
+}

--- a/src/data/HostSelector.ts
+++ b/src/data/HostSelector.ts
@@ -1,5 +1,4 @@
-import { defaultHost } from '../helpers/explore-url';
-import { HostService } from '../services/HostService';
+import { HUMAN } from './api-lapis';
 
 export type HostSelector = string[];
 
@@ -14,11 +13,11 @@ export function addHostSelectorToUrlSearchParams(selector: HostSelector, params:
 
 export function readHostSelectorFromUrlSearchParams(params: URLSearchParams): HostSelector {
   if (!params.has('host')) {
-    return defaultHost;
+    return [HUMAN];
   }
   return params.get('host')!.split(',');
 }
 
 export function isDefaultHostSelector(selector: HostSelector): boolean {
-  return selector.length === 1 && selector[0] === HostService.human;
+  return selector.length === 1 && selector[0] === HUMAN;
 }

--- a/src/data/HostSelector.ts
+++ b/src/data/HostSelector.ts
@@ -1,3 +1,5 @@
+import { defaultHost } from '../helpers/explore-url';
+
 export type HostSelector = string[];
 
 export function addHostSelectorToUrlSearchParams(selector: HostSelector, params: URLSearchParams) {
@@ -9,9 +11,9 @@ export function addHostSelectorToUrlSearchParams(selector: HostSelector, params:
   }
 }
 
-export function readHostSelectorFromUrlSearchParams(params: URLSearchParams): HostSelector | undefined {
+export function readHostSelectorFromUrlSearchParams(params: URLSearchParams): HostSelector {
   if (!params.has('host')) {
-    return undefined;
+    return defaultHost;
   }
   return params.get('host')!.split(',');
 }

--- a/src/data/HostSelector.ts
+++ b/src/data/HostSelector.ts
@@ -1,0 +1,17 @@
+export type HostSelector = string[];
+
+export function addHostSelectorToUrlSearchParams(selector: HostSelector, params: URLSearchParams) {
+  params.delete('host');
+  if (selector.length > 0) {
+    // TODO We assume that the names of the hosts do not have a ",". Is it safe?
+    //  This is currently the case for all of our data.
+    params.set('host', selector.join(','));
+  }
+}
+
+export function readHostSelectorFromUrlSearchParams(params: URLSearchParams): HostSelector | undefined {
+  if (!params.has('host')) {
+    return undefined;
+  }
+  return params.get('host')!.split(',');
+}

--- a/src/data/HostSelector.ts
+++ b/src/data/HostSelector.ts
@@ -1,4 +1,5 @@
 import { defaultHost } from '../helpers/explore-url';
+import { HostService } from '../services/HostService';
 
 export type HostSelector = string[];
 
@@ -16,4 +17,8 @@ export function readHostSelectorFromUrlSearchParams(params: URLSearchParams): Ho
     return defaultHost;
   }
   return params.get('host')!.split(',');
+}
+
+export function isDefaultHostSelector(selector: HostSelector): boolean {
+  return selector.length === 1 && selector[0] === HostService.human;
 }

--- a/src/data/LapisSelector.ts
+++ b/src/data/LapisSelector.ts
@@ -1,0 +1,4 @@
+import { LocationDateVariantSelector } from './LocationDateVariantSelector';
+import { HostAndQcSelector } from './HostAndQcSelector';
+
+export type LapisSelector = LocationDateVariantSelector & HostAndQcSelector;

--- a/src/data/MutationProportionDataset.ts
+++ b/src/data/MutationProportionDataset.ts
@@ -3,12 +3,13 @@ import { MutationProportionEntry } from './MutationProportionEntry';
 import { fetchMutationProportions } from './api-lapis';
 import { LocationDateVariantSelector } from './LocationDateVariantSelector';
 import { SequenceType } from './SequenceType';
+import { LapisSelector } from './LapisSelector';
 
 export type MutationProportionDataset = Dataset<LocationDateVariantSelector, MutationProportionEntry[]>;
 
 export class MutationProportionData {
   static async fromApi(
-    selector: LocationDateVariantSelector,
+    selector: LapisSelector,
     sequenceType: SequenceType,
     signal?: AbortSignal
   ): Promise<MutationProportionDataset> {

--- a/src/data/QcSelector.ts
+++ b/src/data/QcSelector.ts
@@ -1,0 +1,52 @@
+export type QcSelector = {
+  nextcladeQcOverallScoreFrom?: number;
+  nextcladeQcOverallScoreTo?: number;
+  nextcladeQcMissingDataScoreFrom?: number;
+  nextcladeQcMissingDataScoreTo?: number;
+  nextcladeQcMixedSitesScoreFrom?: number;
+  nextcladeQcMixedSitesScoreTo?: number;
+  nextcladeQcPrivateMutationsScoreFrom?: number;
+  nextcladeQcPrivateMutationsScoreTo?: number;
+  nextcladeQcSnpClustersScoreFrom?: number;
+  nextcladeQcSnpClustersScoreTo?: number;
+  nextcladeQcFrameShiftsScoreFrom?: number;
+  nextcladeQcFrameShiftsScoreTo?: number;
+  nextcladeQcStopCodonsScoreFrom?: number;
+  nextcladeQcStopCodonsScoreTo?: number;
+};
+
+const fields = [
+  'nextcladeQcOverallScoreFrom',
+  'nextcladeQcOverallScoreTo',
+  'nextcladeQcMissingDataScoreFrom',
+  'nextcladeQcMissingDataScoreTo',
+  'nextcladeQcMixedSitesScoreFrom',
+  'nextcladeQcMixedSitesScoreTo',
+  'nextcladeQcPrivateMutationsScoreFrom',
+  'nextcladeQcPrivateMutationsScoreTo',
+  'nextcladeQcSnpClustersScoreFrom',
+  'nextcladeQcSnpClustersScoreTo',
+  'nextcladeQcFrameShiftsScoreFrom',
+  'nextcladeQcFrameShiftsScoreTo',
+  'nextcladeQcStopCodonsScoreFrom',
+  'nextcladeQcStopCodonsScoreTo',
+] as const;
+
+export function addQcSelectorToUrlSearchParams(selector: QcSelector, params: URLSearchParams) {
+  for (const field of fields) {
+    params.delete(field);
+    if (selector[field] !== undefined && selector[field] !== null) {
+      params.set(field, selector[field]!.toFixed(0));
+    }
+  }
+}
+
+export function readQcSelectorFromUrlSearchParams(params: URLSearchParams): QcSelector {
+  const qc: QcSelector = {};
+  for (const field of fields) {
+    if (params.has(field)) {
+      qc[field] = Number.parseInt(params.get(field)!);
+    }
+  }
+  return qc;
+}

--- a/src/data/QcSelector.ts
+++ b/src/data/QcSelector.ts
@@ -15,6 +15,44 @@ export type QcSelector = {
   nextcladeQcStopCodonsScoreTo?: number;
 };
 
+export const qcFieldsAndLabels = [
+  {
+    label: 'Overall score',
+    fromField: 'nextcladeQcOverallScoreFrom' as const,
+    toField: 'nextcladeQcOverallScoreTo' as const,
+  },
+  {
+    label: 'Missing data score',
+    fromField: 'nextcladeQcMissingDataScoreFrom' as const,
+    toField: 'nextcladeQcMissingDataScoreTo' as const,
+  },
+  {
+    label: 'Mixed sites score',
+    fromField: 'nextcladeQcMixedSitesScoreFrom' as const,
+    toField: 'nextcladeQcMixedSitesScoreTo' as const,
+  },
+  {
+    label: 'Private mutations score',
+    fromField: 'nextcladeQcPrivateMutationsScoreFrom' as const,
+    toField: 'nextcladeQcPrivateMutationsScoreTo' as const,
+  },
+  {
+    label: 'SNP clusters score',
+    fromField: 'nextcladeQcSnpClustersScoreFrom' as const,
+    toField: 'nextcladeQcSnpClustersScoreTo' as const,
+  },
+  {
+    label: 'Frame shifts score',
+    fromField: 'nextcladeQcFrameShiftsScoreFrom' as const,
+    toField: 'nextcladeQcFrameShiftsScoreTo' as const,
+  },
+  {
+    label: 'Stop codons score',
+    fromField: 'nextcladeQcStopCodonsScoreFrom' as const,
+    toField: 'nextcladeQcStopCodonsScoreTo' as const,
+  },
+];
+
 const fields = [
   'nextcladeQcOverallScoreFrom',
   'nextcladeQcOverallScoreTo',
@@ -35,7 +73,7 @@ const fields = [
 export function addQcSelectorToUrlSearchParams(selector: QcSelector, params: URLSearchParams) {
   for (const field of fields) {
     params.delete(field);
-    if (selector[field] !== undefined && selector[field] !== null) {
+    if (selector[field] !== undefined) {
       params.set(field, selector[field]!.toFixed(0));
     }
   }
@@ -49,4 +87,31 @@ export function readQcSelectorFromUrlSearchParams(params: URLSearchParams): QcSe
     }
   }
   return qc;
+}
+
+export function isDefaultQcSelector(selector: QcSelector): boolean {
+  for (let field of fields) {
+    if (selector[field] !== undefined) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function formatQcSelectorAsString(selector: QcSelector): string {
+  const stringComponents = [];
+  for (let { label, fromField, toField } of qcFieldsAndLabels) {
+    if (selector[fromField] !== undefined || selector[toField] !== undefined) {
+      let s = '';
+      if (selector[fromField] !== undefined) {
+        s += `${selector[fromField]} ≤ `;
+      }
+      s += label;
+      if (selector[toField] !== undefined) {
+        s += ` ≤ ${selector[toField]}`;
+      }
+      stringComponents.push(s);
+    }
+  }
+  return stringComponents.join(', ');
 }

--- a/src/data/VariantSelector.ts
+++ b/src/data/VariantSelector.ts
@@ -41,12 +41,6 @@ export function addVariantSelectorToUrlSearchParams(
   }
 }
 
-export function variantUrlFromSelector(selector: VariantSelector): string {
-  const params = new URLSearchParams();
-  addVariantSelectorToUrlSearchParams(selector, params);
-  return params.toString();
-}
-
 export function variantListUrlFromSelectors(selectors: VariantSelector[]): string {
   const params = new URLSearchParams();
   selectors.forEach(function (selector, index) {

--- a/src/data/VariantSelector.ts
+++ b/src/data/VariantSelector.ts
@@ -41,12 +41,26 @@ export function addVariantSelectorToUrlSearchParams(
   }
 }
 
-export function variantListUrlFromSelectors(selectors: VariantSelector[]): string {
-  const params = new URLSearchParams();
+export function addVariantSelectorsToUrlSearchParams(selectors: VariantSelector[], params: URLSearchParams) {
+  removeVariantSelectorsFromUrlSearchParams(params);
   selectors.forEach(function (selector, index) {
     addVariantSelectorToUrlSearchParams(selector, params, index);
   });
-  return params.toString();
+}
+
+function removeVariantSelectorsFromUrlSearchParams(params: URLSearchParams) {
+  for (const key of [...params.keys()]) {
+    if (
+      key.startsWith('aaMutations') ||
+      key.startsWith('nucMutations') ||
+      key.startsWith('pangoLineage') ||
+      key.startsWith('gisaidClade') ||
+      key.startsWith('nextstrainClade') ||
+      key.startsWith('variantQuery')
+    ) {
+      params.delete(key);
+    }
+  }
 }
 
 export function decodeVariantListFromUrl(query: string): VariantSelector[] {

--- a/src/data/api-lapis.ts
+++ b/src/data/api-lapis.ts
@@ -23,6 +23,7 @@ import { HospDiedAgeSampleEntry } from './sample/HospDiedAgeSampleEntry';
 import { LapisSelector } from './LapisSelector';
 import { addHostSelectorToUrlSearchParams } from './HostSelector';
 import { addQcSelectorToUrlSearchParams } from './QcSelector';
+import { HostCountSampleEntry } from './sample/HostCountSampleEntry';
 
 const HOST = process.env.REACT_APP_LAPIS_HOST;
 
@@ -116,6 +117,13 @@ export async function fetchPangoLineageCountSamples(
   signal?: AbortSignal
 ): Promise<PangoCountSampleEntry[]> {
   return _fetchAggSamples(selector, ['pangoLineage'], signal);
+}
+
+export async function fetchHostCountSamples(
+  selector: LapisSelector,
+  signal?: AbortSignal
+): Promise<HostCountSampleEntry[]> {
+  return _fetchAggSamples(selector, ['host'], signal);
 }
 
 export async function fetchMutationProportions(

--- a/src/data/api-lapis.ts
+++ b/src/data/api-lapis.ts
@@ -1,4 +1,3 @@
-import { LocationDateVariantSelector } from './LocationDateVariantSelector';
 import { LapisInformation, LapisResponse } from './LapisResponse';
 import { DateCountSampleEntry } from './sample/DateCountSampleEntry';
 import { AgeCountSampleEntry } from './sample/AgeCountSampleEntry';
@@ -17,11 +16,13 @@ import { SequenceType } from './SequenceType';
 import { MutationProportionEntry } from './MutationProportionEntry';
 import dayjs from 'dayjs';
 import { LocationService } from '../services/LocationService';
-import { sequenceDataSource } from '../helpers/sequence-data-source';
 import { OrderAndLimitConfig } from './OrderAndLimitConfig';
 import { addSamplingStrategyToUrlSearchParams } from './SamplingStrategy';
 import { DatelessCountrylessCountSampleEntry } from './sample/DatelessCountrylessCountSampleEntry';
 import { HospDiedAgeSampleEntry } from './sample/HospDiedAgeSampleEntry';
+import { LapisSelector } from './LapisSelector';
+import { addHostSelectorToUrlSearchParams } from './HostSelector';
+import { addQcSelectorToUrlSearchParams } from './QcSelector';
 
 const HOST = process.env.REACT_APP_LAPIS_HOST;
 
@@ -65,63 +66,60 @@ export async function fetchAllHosts(): Promise<string[]> {
 }
 
 export async function fetchDateCountSamples(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   signal?: AbortSignal
 ): Promise<DateCountSampleEntry[]> {
   return _fetchAggSamples(selector, ['date'], signal);
 }
 
 export async function fetchAgeCountSamples(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   signal?: AbortSignal
 ): Promise<AgeCountSampleEntry[]> {
   return _fetchAggSamples(selector, ['age'], signal);
 }
 
 export async function fetchDivisionCountSamples(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   signal?: AbortSignal
 ): Promise<DivisionCountSampleEntry[]> {
   return _fetchAggSamples(selector, ['division'], signal);
 }
 
 export async function fetchCountryDateCountSamples(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   signal?: AbortSignal
 ): Promise<CountryDateCountSampleEntry[]> {
   return _fetchAggSamples(selector, ['date', 'country'], signal);
 }
 
 export async function fetchDatelessCountrylessCountSamples(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   signal?: AbortSignal
 ): Promise<DatelessCountrylessCountSampleEntry[]> {
   return _fetchAggSamples(selector, ['division', 'age', 'sex', 'hospitalized', 'died'], signal);
 }
 
 export async function fetchHospDiedAgeSamples(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   signal?: AbortSignal
 ): Promise<HospDiedAgeSampleEntry[]> {
   return _fetchAggSamples(selector, ['age', 'hospitalized', 'died'], signal);
 }
 
-export async function fetchSamplesCount(
-  selector: LocationDateVariantSelector,
-  signal?: AbortSignal
-): Promise<number> {
+export async function fetchSamplesCount(selector: LapisSelector, signal?: AbortSignal): Promise<number> {
   return _fetchAggSamples(selector, [], signal).then(entries => entries[0].count);
 }
 
 export async function fetchPangoLineageCountSamples(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   signal?: AbortSignal
 ): Promise<PangoCountSampleEntry[]> {
   return _fetchAggSamples(selector, ['pangoLineage'], signal);
 }
 
 export async function fetchMutationProportions(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   sequenceType: SequenceType,
   signal?: AbortSignal
 ): Promise<MutationProportionEntry[]> {
@@ -143,30 +141,30 @@ export async function fetchMutationProportions(
 }
 
 export async function getLinkToStrainNames(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   orderAndLimit?: OrderAndLimitConfig
 ): Promise<string> {
   return getLinkTo('strain-names', selector, orderAndLimit);
 }
 
 export async function getLinkToGisaidEpiIsl(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   orderAndLimit?: OrderAndLimitConfig
 ): Promise<string> {
   return getLinkTo('gisaid-epi-isl', selector, orderAndLimit);
 }
 
-export async function getCsvLinkToContributors(selector: LocationDateVariantSelector): Promise<string> {
+export async function getCsvLinkToContributors(selector: LapisSelector): Promise<string> {
   return getLinkTo('contributors', selector, undefined, true, 'csv');
 }
 
-export async function getCsvLinkToDetails(selector: LocationDateVariantSelector): Promise<string> {
+export async function getCsvLinkToDetails(selector: LapisSelector): Promise<string> {
   return getLinkTo('details', selector, undefined, true, 'csv');
 }
 
 export async function getLinkToFasta(
   aligned: boolean,
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   orderAndLimit?: OrderAndLimitConfig
 ): Promise<string> {
   return getLinkTo(aligned ? 'fasta-aligned' : 'fasta', selector, orderAndLimit, true);
@@ -174,7 +172,7 @@ export async function getLinkToFasta(
 
 export async function getLinkTo(
   endpoint: string,
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   orderAndLimit?: OrderAndLimitConfig,
   downloadAsFile?: boolean,
   dataFormat?: string,
@@ -182,7 +180,6 @@ export async function getLinkTo(
   minProportion?: string
 ): Promise<string> {
   const params = new URLSearchParams();
-  _addDefaultsToSearchParams(params);
   _addOrderAndLimitToSearchParams(params, orderAndLimit);
   selector = await _mapCountryName(selector);
   addLocationSelectorToUrlSearchParams(selector.location, params);
@@ -195,6 +192,10 @@ export async function getLinkTo(
   if (selector.samplingStrategy) {
     addSamplingStrategyToUrlSearchParams(selector.samplingStrategy, params);
   }
+  if (selector.host) {
+    addHostSelectorToUrlSearchParams(selector.host, params);
+  }
+  addQcSelectorToUrlSearchParams(selector.qc, params);
   if (downloadAsFile) {
     params.set('downloadAsFile', 'true');
   }
@@ -212,26 +213,14 @@ export async function getLinkTo(
 }
 
 export async function _fetchAggSamples(
-  selector: LocationDateVariantSelector,
+  selector: LapisSelector,
   fields: string[],
   signal?: AbortSignal
 ): Promise<FullSampleAggEntry[]> {
-  const params = new URLSearchParams();
-  params.set('fields', fields.join(','));
-  _addDefaultsToSearchParams(params);
-  selector = await _mapCountryName(selector);
-  addLocationSelectorToUrlSearchParams(selector.location, params);
-  if (selector.dateRange) {
-    addDateRangeSelectorToUrlSearchParams(selector.dateRange, params);
-  }
-  if (selector.variant) {
-    addVariantSelectorToUrlSearchParams(selector.variant, params);
-  }
-  if (selector.samplingStrategy) {
-    addSamplingStrategyToUrlSearchParams(selector.samplingStrategy, params);
-  }
-
-  const res = await get(`/sample/aggregated?${params.toString()}`, signal);
+  const linkPrefix = await getLinkTo('aggregated', selector, undefined, undefined, undefined, true);
+  const additionalParams = new URLSearchParams();
+  additionalParams.set('fields', fields.join(','));
+  const res = await get(`${linkPrefix}&${additionalParams}`, signal);
   if (!res.ok) {
     throw new Error('Error fetching new samples data');
   }
@@ -245,10 +234,6 @@ export async function _fetchAggSamples(
     }));
   }
   return parsed;
-}
-
-function _addDefaultsToSearchParams(params: URLSearchParams) {
-  params.set('host', sequenceDataSource === 'gisaid' ? 'Human' : 'Homo sapiens');
 }
 
 function _addOrderAndLimitToSearchParams(params: URLSearchParams, orderAndLimitConfig?: OrderAndLimitConfig) {

--- a/src/data/api-lapis.ts
+++ b/src/data/api-lapis.ts
@@ -24,8 +24,11 @@ import { LapisSelector } from './LapisSelector';
 import { addHostSelectorToUrlSearchParams } from './HostSelector';
 import { addQcSelectorToUrlSearchParams } from './QcSelector';
 import { HostCountSampleEntry } from './sample/HostCountSampleEntry';
+import { sequenceDataSource } from '../helpers/sequence-data-source';
 
 const HOST = process.env.REACT_APP_LAPIS_HOST;
+
+export const HUMAN = sequenceDataSource === 'gisaid' ? 'Human' : 'Homo sapiens';
 
 let currentLapisDataVersion: number | undefined = undefined;
 

--- a/src/data/api-lapis.ts
+++ b/src/data/api-lapis.ts
@@ -55,6 +55,15 @@ export function getCurrentLapisDataVersionDate(): Date | undefined {
   return currentLapisDataVersion !== undefined ? dayjs.unix(currentLapisDataVersion).toDate() : undefined;
 }
 
+export async function fetchAllHosts(): Promise<string[]> {
+  const res = await get('/sample/aggregated?fields=host');
+  if (!res.ok) {
+    throw new Error('Error fetching new samples data');
+  }
+  const body = (await res.json()) as LapisResponse<{ host: string; count: number }[]>;
+  return _extractLapisData(body).map(e => e.host);
+}
+
 export async function fetchDateCountSamples(
   selector: LocationDateVariantSelector,
   signal?: AbortSignal

--- a/src/data/sample/AgeCountSampleDataset.ts
+++ b/src/data/sample/AgeCountSampleDataset.ts
@@ -2,14 +2,12 @@ import { Dataset } from '../Dataset';
 import { LocationDateVariantSelector } from '../LocationDateVariantSelector';
 import { AgeCountSampleEntry } from './AgeCountSampleEntry';
 import { fetchAgeCountSamples } from '../api-lapis';
+import { LapisSelector } from '../LapisSelector';
 
 export type AgeCountSampleDataset = Dataset<LocationDateVariantSelector, AgeCountSampleEntry[]>;
 
 export class AgeCountSampleData {
-  static async fromApi(
-    selector: LocationDateVariantSelector,
-    signal?: AbortSignal
-  ): Promise<AgeCountSampleDataset> {
+  static async fromApi(selector: LapisSelector, signal?: AbortSignal): Promise<AgeCountSampleDataset> {
     return {
       selector,
       payload: await fetchAgeCountSamples(selector, signal),

--- a/src/data/sample/CountryDateCountSampleDataset.ts
+++ b/src/data/sample/CountryDateCountSampleDataset.ts
@@ -2,6 +2,7 @@ import { Dataset } from '../Dataset';
 import { LocationDateVariantSelector } from '../LocationDateVariantSelector';
 import { CountryDateCountSampleEntry } from './CountryDateCountSampleEntry';
 import { fetchCountryDateCountSamples } from '../api-lapis';
+import { LapisSelector } from '../LapisSelector';
 
 export type CountryDateCountSampleDataset = Dataset<
   LocationDateVariantSelector,
@@ -10,7 +11,7 @@ export type CountryDateCountSampleDataset = Dataset<
 
 export class CountryDateCountSampleData {
   static async fromApi(
-    selector: LocationDateVariantSelector,
+    selector: LapisSelector,
     signal?: AbortSignal
   ): Promise<CountryDateCountSampleDataset> {
     return {

--- a/src/data/sample/DateCountSampleDataset.ts
+++ b/src/data/sample/DateCountSampleDataset.ts
@@ -3,14 +3,12 @@ import { LocationDateVariantSelector } from '../LocationDateVariantSelector';
 import { DateCountSampleEntry } from './DateCountSampleEntry';
 import { fetchDateCountSamples } from '../api-lapis';
 import { UnifiedDay, UnifiedIsoWeek } from '../../helpers/date-cache';
+import { LapisSelector } from '../LapisSelector';
 
 export type DateCountSampleDataset = Dataset<LocationDateVariantSelector, DateCountSampleEntry[]>;
 
 export class DateCountSampleData {
-  static async fromApi(
-    selector: LocationDateVariantSelector,
-    signal?: AbortSignal
-  ): Promise<DateCountSampleDataset> {
+  static async fromApi(selector: LapisSelector, signal?: AbortSignal): Promise<DateCountSampleDataset> {
     return {
       selector: selector,
       payload: await fetchDateCountSamples(selector, signal),

--- a/src/data/sample/DatelessCountrylessCountSampleDataset.ts
+++ b/src/data/sample/DatelessCountrylessCountSampleDataset.ts
@@ -2,6 +2,7 @@ import { LocationDateVariantSelector } from '../LocationDateVariantSelector';
 import { fetchDatelessCountrylessCountSamples } from '../api-lapis';
 import { Dataset } from '../Dataset';
 import { DatelessCountrylessCountSampleEntry } from './DatelessCountrylessCountSampleEntry';
+import { LapisSelector } from '../LapisSelector';
 
 export type DatelessCountrylessCountSampleDataset = Dataset<
   LocationDateVariantSelector,
@@ -10,7 +11,7 @@ export type DatelessCountrylessCountSampleDataset = Dataset<
 
 export class DatelessCountrylessCountSampleData {
   static async fromApi(
-    selector: LocationDateVariantSelector,
+    selector: LapisSelector,
     signal?: AbortSignal
   ): Promise<DatelessCountrylessCountSampleDataset> {
     return {

--- a/src/data/sample/DivisionCountSampleDataset.ts
+++ b/src/data/sample/DivisionCountSampleDataset.ts
@@ -2,14 +2,12 @@ import { Dataset } from '../Dataset';
 import { LocationDateVariantSelector } from '../LocationDateVariantSelector';
 import { DivisionCountSampleEntry } from './DivisionCountSampleEntry';
 import { fetchDivisionCountSamples } from '../api-lapis';
+import { LapisSelector } from '../LapisSelector';
 
 export type DivisionCountSampleDataset = Dataset<LocationDateVariantSelector, DivisionCountSampleEntry[]>;
 
 export class DivisionCountSampleData {
-  static async fromApi(
-    selector: LocationDateVariantSelector,
-    signal?: AbortSignal
-  ): Promise<DivisionCountSampleDataset> {
+  static async fromApi(selector: LapisSelector, signal?: AbortSignal): Promise<DivisionCountSampleDataset> {
     return {
       selector: selector,
       payload: await fetchDivisionCountSamples(selector, signal),

--- a/src/data/sample/FullSampleAggEntry.ts
+++ b/src/data/sample/FullSampleAggEntry.ts
@@ -11,6 +11,7 @@ export type FullSampleAggEntry = {
   died: boolean | null;
   fullyVaccinated: boolean | null;
   pangoLineage: string | null;
+  host: string | null;
   // TODO Add missing fields
   count: number;
 };

--- a/src/data/sample/HospDiedAgeSampleDataset.ts
+++ b/src/data/sample/HospDiedAgeSampleDataset.ts
@@ -2,14 +2,12 @@ import { LocationDateVariantSelector } from '../LocationDateVariantSelector';
 import { Dataset } from '../Dataset';
 import { HospDiedAgeSampleEntry } from './HospDiedAgeSampleEntry';
 import { fetchHospDiedAgeSamples } from '../api-lapis';
+import { LapisSelector } from '../LapisSelector';
 
 export type HospDiedAgeSampleDataset = Dataset<LocationDateVariantSelector, HospDiedAgeSampleEntry[]>;
 
 export class HospDiedAgeSampleData {
-  static async fromApi(
-    selector: LocationDateVariantSelector,
-    signal?: AbortSignal
-  ): Promise<HospDiedAgeSampleDataset> {
+  static async fromApi(selector: LapisSelector, signal?: AbortSignal): Promise<HospDiedAgeSampleDataset> {
     return {
       selector: selector,
       payload: await fetchHospDiedAgeSamples(selector, signal),

--- a/src/data/sample/HostCountSampleDataset.ts
+++ b/src/data/sample/HostCountSampleDataset.ts
@@ -1,0 +1,13 @@
+import { Dataset } from '../Dataset';
+import { LocationDateVariantSelector } from '../LocationDateVariantSelector';
+import { HostCountSampleEntry } from './HostCountSampleEntry';
+import { fetchHostCountSamples } from '../api-lapis';
+import { LapisSelector } from '../LapisSelector';
+
+export type HostCountSampleDataset = Dataset<LocationDateVariantSelector, HostCountSampleEntry[]>;
+
+export class HostCountSampleData {
+  static async fromApi(selector: LapisSelector, signal?: AbortSignal): Promise<HostCountSampleDataset> {
+    return { selector, payload: await fetchHostCountSamples(selector, signal) };
+  }
+}

--- a/src/data/sample/HostCountSampleEntry.ts
+++ b/src/data/sample/HostCountSampleEntry.ts
@@ -1,0 +1,4 @@
+export type HostCountSampleEntry = {
+  host: string | null;
+  count: number;
+};

--- a/src/data/sample/PangoCountSampleDataset.ts
+++ b/src/data/sample/PangoCountSampleDataset.ts
@@ -2,14 +2,12 @@ import { Dataset } from '../Dataset';
 import { LocationDateVariantSelector } from '../LocationDateVariantSelector';
 import { PangoCountSampleEntry } from './PangoCountSampleEntry';
 import { fetchPangoLineageCountSamples } from '../api-lapis';
+import { LapisSelector } from '../LapisSelector';
 
 export type PangoCountSampleDataset = Dataset<LocationDateVariantSelector, PangoCountSampleEntry[]>;
 
 export class PangoCountSampleData {
-  static async fromApi(
-    selector: LocationDateVariantSelector,
-    signal?: AbortSignal
-  ): Promise<PangoCountSampleDataset> {
+  static async fromApi(selector: LapisSelector, signal?: AbortSignal): Promise<PangoCountSampleDataset> {
     return { selector, payload: await fetchPangoLineageCountSamples(selector, signal) };
   }
 }

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -177,7 +177,7 @@ export function useExploreUrl(): ExploreUrl | undefined {
     },
     [history, locationState.pathname, locationState.search, queryString, routeMatches.locationSamplingDate]
   );
-  const setQcAndHost = useCallback(
+  const setHostAndQc = useCallback(
     (host?: HostSelector, qc?: QcSelector) => {
       const newQueryParam = new URLSearchParams(queryString);
       if (host) {
@@ -295,7 +295,7 @@ export function useExploreUrl(): ExploreUrl | undefined {
     setDateRange,
     setVariants,
     setAnalysisMode,
-    setHostAndQc: setQcAndHost,
+    setHostAndQc,
     getOverviewPageUrl,
     getExplorePageUrl,
     getDeepExplorePageUrl,

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -31,6 +31,7 @@ import {
   QcSelector,
   readQcSelectorFromUrlSearchParams,
 } from '../data/QcSelector';
+import { HostService } from '../services/HostService';
 
 export interface ExploreUrl {
   validUrl: true;
@@ -40,7 +41,7 @@ export interface ExploreUrl {
   variants?: VariantSelector[];
   samplingStrategy: SamplingStrategy;
   analysisMode: AnalysisMode;
-  host: HostSelector | undefined;
+  host: HostSelector;
   qc: QcSelector;
 
   setLocation: (location: LocationSelector) => void;
@@ -65,6 +66,8 @@ export const defaultDateRange: DateRangeUrlEncoded = 'Past6M';
 export const defaultSamplingStrategy: SamplingStrategy = SamplingStrategy.AllSamples;
 
 export const defaultAnalysisMode: AnalysisMode = AnalysisMode.Single;
+
+export const defaultHost: HostSelector = [HostService.human];
 
 export function useExploreUrl(): ExploreUrl | undefined {
   const history = useHistory();
@@ -177,7 +180,11 @@ export function useExploreUrl(): ExploreUrl | undefined {
     (host?: HostSelector, qc?: QcSelector) => {
       const newQueryParam = new URLSearchParams(queryString);
       if (host) {
-        addHostSelectorToUrlSearchParams(host, newQueryParam);
+        if (host.length === 1 && host[0] === HostService.human) {
+          addHostSelectorToUrlSearchParams([], newQueryParam);
+        } else {
+          addHostSelectorToUrlSearchParams(host, newQueryParam);
+        }
       }
       if (qc) {
         addQcSelectorToUrlSearchParams(qc, newQueryParam);

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -5,7 +5,6 @@ import {
   decodeVariantListFromUrl,
   variantListUrlFromSelectors,
   VariantSelector,
-  variantUrlFromSelector,
 } from '../data/VariantSelector';
 import {
   decodeLocationSelectorFromSingleString,
@@ -34,7 +33,6 @@ export interface ExploreUrl {
 
   setLocation: (location: LocationSelector) => void;
   setDateRange: (dateRange: DateRangeSelector) => void;
-  setVariant: (variant: VariantSelector) => void;
   setVariants: (variants: VariantSelector[], analysisMode?: AnalysisMode) => void;
   setAnalysisMode: (analysisMode: AnalysisMode) => void;
   setSamplingStrategy: (samplingStrategy: SamplingStrategy) => void;
@@ -120,19 +118,6 @@ export function useExploreUrl(): ExploreUrl | undefined {
       history.push(
         `/explore/${routeMatches.locationSamplingDate.params.location}/${routeMatches.locationSamplingDate.params.samplingStrategy}/${dateRangeEncoded}${suffix}`
       );
-    },
-    [history, locationState.pathname, locationState.search, routeMatches.locationSamplingDate]
-  );
-  const setVariant = useCallback(
-    (variant: VariantSelector) => {
-      if (!routeMatches.locationSamplingDate) {
-        return;
-      }
-      const prefix = `/explore/${routeMatches.locationSamplingDate.params.location}/${routeMatches.locationSamplingDate.params.samplingStrategy}/${routeMatches.locationSamplingDate.params.dateRange}`;
-      const currentPath = locationState.pathname + locationState.search;
-      assert(currentPath.startsWith(prefix));
-      const variantEncoded = variantUrlFromSelector(variant);
-      history.push(`${prefix}/variants?${variantEncoded}`);
     },
     [history, locationState.pathname, locationState.search, routeMatches.locationSamplingDate]
   );
@@ -258,7 +243,6 @@ export function useExploreUrl(): ExploreUrl | undefined {
     setLocation,
     setSamplingStrategy,
     setDateRange,
-    setVariant,
     setVariants,
     setAnalysisMode,
     getOverviewPageUrl,

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -32,7 +32,7 @@ import {
   QcSelector,
   readQcSelectorFromUrlSearchParams,
 } from '../data/QcSelector';
-import { HostService } from '../services/HostService';
+import { HUMAN } from '../data/api-lapis';
 
 export interface ExploreUrl {
   validUrl: true;
@@ -68,7 +68,7 @@ export const defaultSamplingStrategy: SamplingStrategy = SamplingStrategy.AllSam
 
 export const defaultAnalysisMode: AnalysisMode = AnalysisMode.Single;
 
-export const defaultHost: HostSelector = [HostService.human];
+export const defaultHost: HostSelector = [HUMAN];
 
 export function useExploreUrl(): ExploreUrl | undefined {
   const history = useHistory();

--- a/src/helpers/explore-url.ts
+++ b/src/helpers/explore-url.ts
@@ -24,6 +24,7 @@ import { AnalysisMode, decodeAnalysisMode } from '../data/AnalysisMode';
 import {
   addHostSelectorToUrlSearchParams,
   HostSelector,
+  isDefaultHostSelector,
   readHostSelectorFromUrlSearchParams,
 } from '../data/HostSelector';
 import {
@@ -180,7 +181,7 @@ export function useExploreUrl(): ExploreUrl | undefined {
     (host?: HostSelector, qc?: QcSelector) => {
       const newQueryParam = new URLSearchParams(queryString);
       if (host) {
-        if (host.length === 1 && host[0] === HostService.human) {
+        if (isDefaultHostSelector(host)) {
           addHostSelectorToUrlSearchParams([], newQueryParam);
         } else {
           addHostSelectorToUrlSearchParams(host, newQueryParam);

--- a/src/helpers/selectors-from-explore-url-hook.ts
+++ b/src/helpers/selectors-from-explore-url-hook.ts
@@ -1,20 +1,22 @@
 import { ExploreUrl } from './explore-url';
 import { useDeepCompareMemo } from './deep-compare-hooks';
-import { LocationDateVariantSelector } from '../data/LocationDateVariantSelector';
 import { LocationDateSelector } from '../data/LocationDateSelector';
+import { LapisSelector } from '../data/LapisSelector';
+import { HostAndQcSelector } from '../data/HostAndQcSelector';
 
 export type SingleSelectorsFromExploreUrlHook = {
-  ldvsSelector: LocationDateVariantSelector;
-  ldsSelector: LocationDateVariantSelector;
-  lvsSelector: LocationDateVariantSelector;
-  lsSelector: LocationDateVariantSelector;
-  dvsSelector: LocationDateVariantSelector;
-  dsSelector: LocationDateVariantSelector;
+  ldvsSelector: LapisSelector;
+  ldsSelector: LapisSelector;
+  lvsSelector: LapisSelector;
+  lsSelector: LapisSelector;
+  dvsSelector: LapisSelector;
+  dsSelector: LapisSelector;
   lSelector: LocationDateSelector;
+  hostAndQc: HostAndQcSelector;
 };
 
 export type MultipleSelectorsFromExploreUrlHook = {
-  ldvsSelectors: LocationDateVariantSelector[];
+  ldvsSelectors: LapisSelector[];
 };
 
 /**
@@ -29,54 +31,87 @@ export function useSingleSelectorsFromExploreUrl(exploreUrl: ExploreUrl): Single
         dateRange: exploreUrl.dateRange,
         samplingStrategy: exploreUrl.samplingStrategy!,
         variant: firstVariant,
+        host: exploreUrl.host,
+        qc: exploreUrl.qc,
       }),
-      [exploreUrl.dateRange, exploreUrl.location, exploreUrl.samplingStrategy, firstVariant]
+      [
+        exploreUrl.dateRange,
+        exploreUrl.location,
+        exploreUrl.samplingStrategy,
+        firstVariant,
+        exploreUrl.host,
+        exploreUrl.qc,
+      ]
     ),
     ldsSelector: useDeepCompareMemo(
       () => ({
         location: exploreUrl.location!,
         dateRange: exploreUrl.dateRange,
         samplingStrategy: exploreUrl.samplingStrategy!,
+        host: exploreUrl.host,
+        qc: exploreUrl.qc,
       }),
-      [exploreUrl.dateRange, exploreUrl.location, exploreUrl.samplingStrategy]
+      [exploreUrl.dateRange, exploreUrl.location, exploreUrl.samplingStrategy, exploreUrl.host, exploreUrl.qc]
     ),
     lvsSelector: useDeepCompareMemo(
       () => ({
         location: exploreUrl.location!,
         samplingStrategy: exploreUrl.samplingStrategy!,
         variant: firstVariant,
+        host: exploreUrl.host,
+        qc: exploreUrl.qc,
       }),
-      [exploreUrl.dateRange, exploreUrl.location, exploreUrl.samplingStrategy, firstVariant]
+      [
+        exploreUrl.dateRange,
+        exploreUrl.location,
+        exploreUrl.samplingStrategy,
+        firstVariant,
+        exploreUrl.host,
+        exploreUrl.qc,
+      ]
     ),
     lsSelector: useDeepCompareMemo(
       () => ({
         location: exploreUrl.location!,
         samplingStrategy: exploreUrl.samplingStrategy!,
+        host: exploreUrl.host,
+        qc: exploreUrl.qc,
       }),
-      [exploreUrl.location, exploreUrl.samplingStrategy]
+      [exploreUrl.location, exploreUrl.samplingStrategy, exploreUrl.host, exploreUrl.qc]
     ),
     dvsSelector: useDeepCompareMemo(
       () => ({
         location: {},
         dateRange: exploreUrl.dateRange,
         samplingStrategy: exploreUrl.samplingStrategy!,
+        host: exploreUrl.host,
+        qc: exploreUrl.qc,
         variant: firstVariant,
       }),
-      [exploreUrl.dateRange, exploreUrl.samplingStrategy, firstVariant]
+      [exploreUrl.dateRange, exploreUrl.samplingStrategy, firstVariant, exploreUrl.host, exploreUrl.qc]
     ),
     dsSelector: useDeepCompareMemo(
       () => ({
         location: {},
         dateRange: exploreUrl.dateRange,
         samplingStrategy: exploreUrl.samplingStrategy!,
+        host: exploreUrl.host,
+        qc: exploreUrl.qc,
       }),
-      [exploreUrl.dateRange, exploreUrl.samplingStrategy]
+      [exploreUrl.dateRange, exploreUrl.samplingStrategy, exploreUrl.host, exploreUrl.qc]
     ),
     lSelector: useDeepCompareMemo(
       () => ({
         location: exploreUrl.location!,
       }),
       [exploreUrl.location]
+    ),
+    hostAndQc: useDeepCompareMemo(
+      () => ({
+        host: exploreUrl.host,
+        qc: exploreUrl.qc,
+      }),
+      [exploreUrl.host, exploreUrl.qc]
     ),
   };
 }
@@ -92,8 +127,17 @@ export function useMultipleSelectorsFromExploreUrl(
           dateRange: exploreUrl.dateRange,
           samplingStrategy: exploreUrl.samplingStrategy!,
           variant,
+          host: exploreUrl.host,
+          qc: exploreUrl.qc,
         })),
-      [exploreUrl.dateRange, exploreUrl.location, exploreUrl.samplingStrategy, exploreUrl.variants]
+      [
+        exploreUrl.dateRange,
+        exploreUrl.location,
+        exploreUrl.samplingStrategy,
+        exploreUrl.variants,
+        exploreUrl.host,
+        exploreUrl.qc,
+      ]
     ),
   };
 }

--- a/src/models/althaus2021Growth/Althaus2021GrowthWidget.tsx
+++ b/src/models/althaus2021Growth/Althaus2021GrowthWidget.tsx
@@ -7,6 +7,7 @@ import {
   LocationDateVariantSelectorEncodedSchema,
 } from '../../data/LocationDateVariantSelector';
 import { DateCountSampleData } from '../../data/sample/DateCountSampleDataset';
+import { addDefaultHostAndQc } from '../../data/HostAndQcSelector';
 
 export const Althaus2021GrowthWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -19,8 +20,8 @@ export const Althaus2021GrowthWidget = new Widget(
         variant: undefined,
       };
       return {
-        variantDateCounts: await DateCountSampleData.fromApi(variantSelector, signal),
-        wholeDateCounts: await DateCountSampleData.fromApi(wholeSelector, signal),
+        variantDateCounts: await DateCountSampleData.fromApi(addDefaultHostAndQc(variantSelector), signal),
+        wholeDateCounts: await DateCountSampleData.fromApi(addDefaultHostAndQc(wholeSelector), signal),
       };
     }
   ),

--- a/src/models/chen2021Fitness/Chen2021FitnessContainer.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessContainer.tsx
@@ -7,15 +7,15 @@ import { fillRequestWithDefaults, transformToRequestData } from './loading';
 import { ExternalLink } from '../../components/ExternalLink';
 import { DateCountSampleData } from '../../data/sample/DateCountSampleDataset';
 import { globalDateCache, UnifiedDay } from '../../helpers/date-cache';
-import { LocationDateVariantSelector } from '../../data/LocationDateVariantSelector';
 import dayjs from 'dayjs';
 import { useQuery } from '../../helpers/query-hook';
 import { FixedDateRangeSelector } from '../../data/DateRangeSelector';
 import Loader from '../../components/Loader';
 import { CaseCountData } from '../../data/CaseCountDataset';
+import { LapisSelector } from '../../data/LapisSelector';
 
 export type ContainerProps = {
-  selector: LocationDateVariantSelector;
+  selector: LapisSelector;
   defaults?: {
     startDate: UnifiedDay;
     initialWildtypeCases: number;

--- a/src/models/chen2021Fitness/Chen2021FitnessWidget.tsx
+++ b/src/models/chen2021Fitness/Chen2021FitnessWidget.tsx
@@ -6,13 +6,14 @@ import {
   encodeLocationDateVariantSelector,
   LocationDateVariantSelectorEncodedSchema,
 } from '../../data/LocationDateVariantSelector';
+import { addDefaultHostAndQc } from '../../data/HostAndQcSelector';
 
 export const Chen2021FitnessWidget = new Widget(
   new AsyncZodQueryEncoder(
     LocationDateVariantSelectorEncodedSchema,
     async (v: ContainerProps) => encodeLocationDateVariantSelector(v.selector),
     async encoded => {
-      return { selector: decodeLocationDateVariantSelector(encoded) };
+      return { selector: addDefaultHostAndQc(decodeLocationDateVariantSelector(encoded)) };
     }
   ),
   Chen2021FitnessContainer,

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -13,6 +13,7 @@ import Loader from '../components/Loader';
 import { VariantSearch } from '../components/VariantSearch';
 import { AnalysisMode } from '../data/AnalysisMode';
 import { getLocation } from '../helpers/get-location';
+import { useSingleSelectorsFromExploreUrl } from '../helpers/selectors-from-explore-url-hook';
 
 type Props = {
   isSmallScreen: boolean;
@@ -20,27 +21,18 @@ type Props = {
 
 export const ExplorePage = ({ isSmallScreen }: Props) => {
   const exploreUrl = useExploreUrl();
+  const { lsSelector, lSelector, hostAndQc } = useSingleSelectorsFromExploreUrl(exploreUrl!);
 
   // Fetch data
   const wholeDatelessDataset = useQuery(
-    signal =>
-      DatelessCountrylessCountSampleData.fromApi(
-        { location: exploreUrl?.location!, samplingStrategy: exploreUrl?.samplingStrategy! },
-        signal
-      ),
-    [exploreUrl?.location, exploreUrl?.samplingStrategy]
+    signal => DatelessCountrylessCountSampleData.fromApi(lsSelector, signal),
+    [lsSelector]
   );
-  const wholeDateCountDataset = useQuery(
-    signal =>
-      DateCountSampleData.fromApi(
-        { location: exploreUrl?.location!, samplingStrategy: exploreUrl?.samplingStrategy! },
-        signal
-      ),
-    [exploreUrl?.location, exploreUrl?.samplingStrategy]
-  );
-  const caseCountDataset: CaseCountAsyncDataset = useAsyncDataset(
-    { location: exploreUrl?.location! },
-    ({ selector }, { signal }) => CaseCountData.fromApi(selector, signal)
+  const wholeDateCountDataset = useQuery(signal => DateCountSampleData.fromApi(lsSelector, signal), [
+    lsSelector,
+  ]);
+  const caseCountDataset: CaseCountAsyncDataset = useAsyncDataset(lSelector, ({ selector }, { signal }) =>
+    CaseCountData.fromApi(selector, signal)
   );
 
   useEffect(() => {
@@ -70,6 +62,7 @@ export const ExplorePage = ({ isSmallScreen }: Props) => {
             onVariantSelect={exploreUrl.setVariants}
             wholeDateCountSampleDataset={wholeDateCountDataset.data}
             variantSelector={undefined}
+            hostAndQc={hostAndQc}
             isHorizontal={false}
             isLandingPage={true}
           />

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -67,7 +67,7 @@ export const ExplorePage = ({ isSmallScreen }: Props) => {
           <h1 className='mt-4'>Known variants</h1>
           <p>Which variant would you like to explore?</p>
           <KnownVariantsList
-            onVariantSelect={exploreUrl.setVariant}
+            onVariantSelect={exploreUrl.setVariants}
             wholeDateCountSampleDataset={wholeDateCountDataset.data}
             variantSelector={undefined}
             isHorizontal={false}

--- a/src/pages/FocusCompareToBaselinePage.tsx
+++ b/src/pages/FocusCompareToBaselinePage.tsx
@@ -9,7 +9,6 @@ import { MultiVariantTimeDistributionLineChart } from '../widgets/MultiVariantTi
 import { NamedCard } from '../components/NamedCard';
 import { AnalysisMode } from '../data/AnalysisMode';
 import { Chen2021FitnessPreview } from '../models/chen2021Fitness/Chen2021FitnessPreview';
-import { LocationDateVariantSelector } from '../data/LocationDateVariantSelector';
 import { Althaus2021GrowthWidget } from '../models/althaus2021Growth/Althaus2021GrowthWidget';
 import { FullSampleAggEntry, FullSampleAggEntryField } from '../data/sample/FullSampleAggEntry';
 import { _fetchAggSamples } from '../data/api-lapis';
@@ -17,6 +16,7 @@ import { Utils } from '../services/Utils';
 import { useDeepCompareMemo } from '../helpers/deep-compare-hooks';
 import { DivisionModal } from '../components/DivisionModal';
 import { createDivisionBreakdownButton } from './FocusSinglePage';
+import { LapisSelector } from '../data/LapisSelector';
 
 export const FocusCompareToBaselinePage = () => {
   const exploreUrl = useExploreUrl()!;
@@ -34,11 +34,9 @@ export const FocusCompareToBaselinePage = () => {
   );
 
   // Fetch the whole sample set which, in this case, means the union of all selected variant.
-  const wholeSelector: LocationDateVariantSelector = useMemo(
+  const wholeSelector: LapisSelector = useMemo(
     () => ({
-      location: ldvsSelectors[0].location,
-      dateRange: ldvsSelectors[0].dateRange,
-      samplingStrategy: ldvsSelectors[0].samplingStrategy,
+      ...ldvsSelectors[0],
       variant: {
         variantQuery: ldvsSelectors
           .map(ldvsSelector => `(${transformToVariantQuery(ldvsSelector.variant!)})`)

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -60,7 +60,7 @@ export const FocusPage = ({ isSmallScreen }: Props) => {
           {wholeDateCountWithoutDateFilter.data ? (
             <div id='explore-selectors'>
               <KnownVariantsList
-                onVariantSelect={exploreUrl.setVariant}
+                onVariantSelect={exploreUrl.setVariants}
                 wholeDateCountSampleDataset={wholeDateCountWithoutDateFilter.data}
                 variantSelector={exploreUrl.variants}
                 isHorizontal={isSmallScreen}

--- a/src/pages/FocusPage.tsx
+++ b/src/pages/FocusPage.tsx
@@ -24,7 +24,7 @@ export const FocusPage = ({ isSmallScreen }: Props) => {
   const exploreUrl = useExploreUrl()!;
 
   // fetch data
-  const { lsSelector } = useSingleSelectorsFromExploreUrl(exploreUrl);
+  const { lsSelector, hostAndQc } = useSingleSelectorsFromExploreUrl(exploreUrl);
   const wholeDateCountWithoutDateFilter = useQuery(
     signal => DateCountSampleData.fromApi(lsSelector, signal),
     [lsSelector]
@@ -63,6 +63,7 @@ export const FocusPage = ({ isSmallScreen }: Props) => {
                 onVariantSelect={exploreUrl.setVariants}
                 wholeDateCountSampleDataset={wholeDateCountWithoutDateFilter.data}
                 variantSelector={exploreUrl.variants}
+                hostAndQc={hostAndQc}
                 isHorizontal={isSmallScreen}
                 isLandingPage={false}
               />

--- a/src/pages/FocusSinglePage.tsx
+++ b/src/pages/FocusSinglePage.tsx
@@ -276,16 +276,7 @@ export const FocusSinglePage = () => {
       <VariantHeader
         dateRange={exploreUrl.dateRange}
         variant={exploreUrl.variant}
-        controls={
-          <FocusVariantHeaderControls
-            selector={{
-              location: exploreUrl.location,
-              dateRange: exploreUrl.dateRange,
-              variant: exploreUrl.variant,
-              samplingStrategy: exploreUrl.samplingStrategy,
-            }}
-          />
-        }
+        controls={<FocusVariantHeaderControls selector={ldvsSelector} />}
       />
       {variantDateCount.data &&
       wholeDateCountWithDateFilter.data &&
@@ -305,10 +296,7 @@ export const FocusSinglePage = () => {
             />
             {(!pangoLineage || pangoLineage.endsWith('*')) && (
               <div className='mx-0.5 mt-1 mb-5 md:mx-3 shadow-lg rounded-lg bg-white p-2 pl-4'>
-                <VariantLineages
-                  onVariantSelect={exploreUrl.setVariants}
-                  selector={variantDateCount.data.selector}
-                />{' '}
+                <VariantLineages onVariantSelect={exploreUrl.setVariants} selector={ldvsSelector} />{' '}
               </div>
             )}
             <PackedGrid maxColumns={2}>
@@ -437,7 +425,7 @@ export const FocusSinglePage = () => {
 
             <div className='m-4'>
               <Sentry.ErrorBoundary fallback={<ErrorBoundaryFallback />}>
-                <VariantMutations selector={variantDateCount.data.selector} />
+                <VariantMutations selector={ldvsSelector} />
               </Sentry.ErrorBoundary>
             </div>
           </div>

--- a/src/pages/FocusSinglePage.tsx
+++ b/src/pages/FocusSinglePage.tsx
@@ -306,7 +306,7 @@ export const FocusSinglePage = () => {
             {(!pangoLineage || pangoLineage.endsWith('*')) && (
               <div className='mx-0.5 mt-1 mb-5 md:mx-3 shadow-lg rounded-lg bg-white p-2 pl-4'>
                 <VariantLineages
-                  onVariantSelect={exploreUrl.setVariant}
+                  onVariantSelect={exploreUrl.setVariants}
                   selector={variantDateCount.data.selector}
                 />{' '}
               </div>

--- a/src/pages/FocusSinglePage.tsx
+++ b/src/pages/FocusSinglePage.tsx
@@ -40,6 +40,8 @@ import { HospitalizationDeathChartWidget } from '../widgets/HospitalizationDeath
 import { useSingleSelectorsFromExploreUrl } from '../helpers/selectors-from-explore-url-hook';
 import { ErrorBoundaryFallback } from '../components/ErrorBoundaryFallback';
 import * as Sentry from '@sentry/react';
+import { isDefaultHostSelector } from '../data/HostSelector';
+import { VariantHosts } from '../components/VariantHosts';
 
 // Due to missing additional data, we are currently not able to maintain some of our Swiss specialties.
 const SWISS_SPECIALTIES_ACTIVATED = false;
@@ -232,6 +234,7 @@ export const FocusSinglePage = () => {
   }
   const { pangoLineage } = exploreUrl.variant;
   const { country } = exploreUrl.location;
+  const host = exploreUrl.host;
 
   // Wastewater plot
   let wasteWaterSummaryPlot = undefined;
@@ -294,9 +297,14 @@ export const FocusSinglePage = () => {
               variantSampleSet={variantDateCount.data}
               wholeSampleSet={wholeDateCountWithDateFilter.data}
             />
+            {!isDefaultHostSelector(host) && (
+              <div className='mx-0.5 mt-1 mb-5 md:mx-3 shadow-lg rounded-lg bg-white p-2 pl-4'>
+                <VariantHosts selector={ldvsSelector} />
+              </div>
+            )}
             {(!pangoLineage || pangoLineage.endsWith('*')) && (
               <div className='mx-0.5 mt-1 mb-5 md:mx-3 shadow-lg rounded-lg bg-white p-2 pl-4'>
-                <VariantLineages onVariantSelect={exploreUrl.setVariants} selector={ldvsSelector} />{' '}
+                <VariantLineages onVariantSelect={exploreUrl.setVariants} selector={ldvsSelector} />
               </div>
             )}
             <PackedGrid maxColumns={2}>
@@ -316,20 +324,22 @@ export const FocusSinglePage = () => {
                   />
                 }
               </GridCell>
-              <GridCell minWidth={600}>
-                <EstimatedCasesChartWidget.ShareableComponent
-                  caseCounts={caseCountDataset}
-                  variantDateCounts={variantDateCount.data}
-                  wholeDateCounts={wholeDateCountWithDateFilter.data}
-                  height={300}
-                  title='Estimated cases'
-                  toolbarChildren={
-                    !country || (SWISS_SPECIALTIES_ACTIVATED && country === 'Switzerland')
-                      ? [createDivisionBreakdownButton('EstimatedCases', setShowEstimatedCasesDivGrid)]
-                      : []
-                  }
-                />
-              </GridCell>
+              {isDefaultHostSelector(host) && (
+                <GridCell minWidth={600}>
+                  <EstimatedCasesChartWidget.ShareableComponent
+                    caseCounts={caseCountDataset}
+                    variantDateCounts={variantDateCount.data}
+                    wholeDateCounts={wholeDateCountWithDateFilter.data}
+                    height={300}
+                    title='Estimated cases'
+                    toolbarChildren={
+                      !country || (SWISS_SPECIALTIES_ACTIVATED && country === 'Switzerland')
+                        ? [createDivisionBreakdownButton('EstimatedCases', setShowEstimatedCasesDivGrid)]
+                        : []
+                    }
+                  />
+                </GridCell>
+              )}
               <GridCell minWidth={600}>
                 <VariantInternationalComparisonChartWidget.ShareableComponent
                   preSelectedCountries={country ? [country] : []}
@@ -382,18 +392,20 @@ export const FocusSinglePage = () => {
                   wholeDateCounts={wholeDateCountWithDateFilter.data}
                 />
               </GridCell>
-              <GridCell minWidth={600}>
-                <VariantAgeDistributionChartWidget.ShareableComponent
-                  title='Age demographics'
-                  height={300}
-                  variantSampleSet={variantAgeCount.data}
-                  wholeSampleSet={wholeAgeCount.data}
-                  toolbarChildren={[
-                    createDivisionBreakdownButton('AgeDemographics', setShowVariantAgeDistributionDivGrid),
-                  ]}
-                />
-              </GridCell>
-              {SWISS_SPECIALTIES_ACTIVATED && country === 'Switzerland' && (
+              {isDefaultHostSelector(host) && (
+                <GridCell minWidth={600}>
+                  <VariantAgeDistributionChartWidget.ShareableComponent
+                    title='Age demographics'
+                    height={300}
+                    variantSampleSet={variantAgeCount.data}
+                    wholeSampleSet={wholeAgeCount.data}
+                    toolbarChildren={[
+                      createDivisionBreakdownButton('AgeDemographics', setShowVariantAgeDistributionDivGrid),
+                    ]}
+                  />
+                </GridCell>
+              )}
+              {SWISS_SPECIALTIES_ACTIVATED && country === 'Switzerland' && isDefaultHostSelector(host) && (
                 <GridCell minWidth={600}>
                   <HospitalizationDeathChartWidget.ShareableComponent
                     extendedMetrics={false}
@@ -408,7 +420,7 @@ export const FocusSinglePage = () => {
                   />
                 </GridCell>
               )}
-              {wasteWaterSummaryPlot}
+              {isDefaultHostSelector(host) && wasteWaterSummaryPlot}
               {exploreUrl?.variant?.pangoLineage && ( // TODO Check that nothing else is set
                 <GridCell minWidth={800}>
                   {articleDataset.data && articleDataset.isSuccess ? (

--- a/src/services/HostService.ts
+++ b/src/services/HostService.ts
@@ -1,0 +1,8 @@
+import { sequenceDataSource } from '../helpers/sequence-data-source';
+import { fetchAllHosts } from '../data/api-lapis';
+
+export class HostService {
+  static human = sequenceDataSource === 'gisaid' ? 'Human' : 'Homo sapiens';
+
+  static allHosts: Promise<string[]> = fetchAllHosts();
+}

--- a/src/services/HostService.ts
+++ b/src/services/HostService.ts
@@ -1,8 +1,5 @@
-import { sequenceDataSource } from '../helpers/sequence-data-source';
 import { fetchAllHosts } from '../data/api-lapis';
 
 export class HostService {
-  static human = sequenceDataSource === 'gisaid' ? 'Human' : 'Homo sapiens';
-
   static allHosts: Promise<string[]> = fetchAllHosts();
 }

--- a/src/services/Utils.ts
+++ b/src/services/Utils.ts
@@ -57,4 +57,14 @@ export class Utils {
   static getRandomColorCode(): string {
     return '#' + Math.floor(Math.random() * (16 ** 6 - 1)).toString(16);
   }
+
+  static safeParseInt(s: string | null | undefined): number | undefined {
+    try {
+      if (s) {
+        return Number.parseInt(s);
+      }
+    } catch (_) {
+      return undefined;
+    }
+  }
 }

--- a/src/services/external-integrations/Integration.ts
+++ b/src/services/external-integrations/Integration.ts
@@ -1,10 +1,11 @@
 import { LocationDateVariantSelector } from '../../data/LocationDateVariantSelector';
 import { variantIsOnlyDefinedBy } from '../../data/VariantSelector';
+import { LapisSelector } from '../../data/LapisSelector';
 
 export interface Integration {
   name: string;
-  isAvailable(selector: LocationDateVariantSelector): boolean;
-  open(selector: LocationDateVariantSelector): void;
+  isAvailable(selector: LapisSelector): boolean;
+  open(selector: LapisSelector): void;
 }
 
 /**

--- a/src/services/external-integrations/NextcladeIntegration.ts
+++ b/src/services/external-integrations/NextcladeIntegration.ts
@@ -1,17 +1,17 @@
 import { Integration } from './Integration';
-import { LocationDateVariantSelector } from '../../data/LocationDateVariantSelector';
 import { sequenceDataSource } from '../../helpers/sequence-data-source';
 import { OrderAndLimitConfig } from '../../data/OrderAndLimitConfig';
 import { getLinkToFasta } from '../../data/api-lapis';
+import { LapisSelector } from '../../data/LapisSelector';
 
 export class NextcladeIntegration implements Integration {
   name = 'Nextclade';
 
-  isAvailable(_: LocationDateVariantSelector): boolean {
+  isAvailable(_: LapisSelector): boolean {
     return sequenceDataSource === 'open';
   }
 
-  async open(selector: LocationDateVariantSelector) {
+  async open(selector: LapisSelector) {
     const orderAndLimit: OrderAndLimitConfig = {
       orderBy: 'random',
       limit: 200,

--- a/src/services/external-integrations/UsherIntegration.ts
+++ b/src/services/external-integrations/UsherIntegration.ts
@@ -1,8 +1,8 @@
 import { Integration } from './Integration';
-import { LocationDateVariantSelector } from '../../data/LocationDateVariantSelector';
 import { getLinkToGisaidEpiIsl, getLinkToStrainNames } from '../../data/api-lapis';
 import { sequenceDataSource } from '../../helpers/sequence-data-source';
 import { OrderAndLimitConfig } from '../../data/OrderAndLimitConfig';
+import { LapisSelector } from '../../data/LapisSelector';
 
 const usherUrl =
   'https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&phyloPlaceTree=hgPhyloPlaceData/wuhCor1' +
@@ -12,11 +12,11 @@ const defaultOrderAndLimit: OrderAndLimitConfig = { orderBy: 'random', limit: 10
 export class UsherIntegration implements Integration {
   name = 'UShER';
 
-  isAvailable(_: LocationDateVariantSelector): boolean {
+  isAvailable(_: LapisSelector): boolean {
     return true;
   }
 
-  open(selector: LocationDateVariantSelector): void {
+  open(selector: LapisSelector): void {
     (sequenceDataSource === 'gisaid'
       ? getLinkToGisaidEpiIsl(selector, defaultOrderAndLimit)
       : getLinkToStrainNames(selector, defaultOrderAndLimit)

--- a/src/stories/Omicron.tsx
+++ b/src/stories/Omicron.tsx
@@ -9,6 +9,7 @@ import { VariantInternationalComparisonMap } from '../widgets/VariantInternation
 import { ExternalLink } from '../components/ExternalLink';
 import { VariantInternationalComparisonChart } from '../widgets/VariantInternationalComparisonChart';
 import { SamplingStrategy } from '../data/SamplingStrategy';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 const UpdateBox = ({
   title,
@@ -71,27 +72,31 @@ const Omicron = () => {
   const FROM_DATE = '2021-10-24';
 
   useEffect(() => {
-    CountryDateCountSampleData.fromApi({
-      location: {},
-      variant: {
-        pangoLineage: 'B.1.1.529*',
-      },
-      dateRange: new FixedDateRangeSelector({
-        dateFrom: globalDateCache.getDay(FROM_DATE),
-        dateTo: globalDateCache.today(),
-      }),
-      samplingStrategy: SamplingStrategy.AllSamples,
-    }).then(r => {
+    CountryDateCountSampleData.fromApi(
+      addDefaultHostAndQc({
+        location: {},
+        variant: {
+          pangoLineage: 'B.1.1.529*',
+        },
+        dateRange: new FixedDateRangeSelector({
+          dateFrom: globalDateCache.getDay(FROM_DATE),
+          dateTo: globalDateCache.today(),
+        }),
+        samplingStrategy: SamplingStrategy.AllSamples,
+      })
+    ).then(r => {
       setVariantSampleSet(r);
     });
-    CountryDateCountSampleData.fromApi({
-      location: {},
-      dateRange: new FixedDateRangeSelector({
-        dateFrom: globalDateCache.getDay(FROM_DATE),
-        dateTo: globalDateCache.today(),
-      }),
-      samplingStrategy: SamplingStrategy.AllSamples,
-    }).then(r => {
+    CountryDateCountSampleData.fromApi(
+      addDefaultHostAndQc({
+        location: {},
+        dateRange: new FixedDateRangeSelector({
+          dateFrom: globalDateCache.getDay(FROM_DATE),
+          dateTo: globalDateCache.today(),
+        }),
+        samplingStrategy: SamplingStrategy.AllSamples,
+      })
+    ).then(r => {
       setWholeSampleSet(r);
     });
   }, []);

--- a/src/widgets/EstimatedCasesChartWidget.ts
+++ b/src/widgets/EstimatedCasesChartWidget.ts
@@ -11,6 +11,7 @@ import { DateCountSampleData } from '../data/sample/DateCountSampleDataset';
 import { CaseCountAsyncDataset, CaseCountData } from '../data/CaseCountDataset';
 import { AsyncStatusTypes } from '../data/AsyncDataset';
 import { LocationDateSelector } from '../data/LocationDateSelector';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export const EstimatedCasesChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -28,8 +29,8 @@ export const EstimatedCasesChartWidget = new Widget(
         dateRange: variantSelector.dateRange,
       };
       return {
-        variantDateCounts: await DateCountSampleData.fromApi(variantSelector, signal),
-        wholeDateCounts: await DateCountSampleData.fromApi(wholeSelector, signal),
+        variantDateCounts: await DateCountSampleData.fromApi(addDefaultHostAndQc(variantSelector), signal),
+        wholeDateCounts: await DateCountSampleData.fromApi(addDefaultHostAndQc(wholeSelector), signal),
         caseCounts: {
           selector: caseSelector,
           payload: (await CaseCountData.fromApi(caseSelector, signal)).payload,

--- a/src/widgets/HospitalizationDeathChartWidget.ts
+++ b/src/widgets/HospitalizationDeathChartWidget.ts
@@ -8,6 +8,7 @@ import {
 } from '../data/LocationDateVariantSelector';
 import { HospitalizationDeathChart, HospitalizationDeathChartProps } from './HospitalizationDeathChart';
 import { HospDiedAgeSampleData } from '../data/sample/HospDiedAgeSampleDataset';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export const HospitalizationDeathChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -30,8 +31,8 @@ export const HospitalizationDeathChartWidget = new Widget(
         variant: undefined,
       };
       return {
-        variantSampleSet: await HospDiedAgeSampleData.fromApi(variantSelector, signal),
-        wholeSampleSet: await HospDiedAgeSampleData.fromApi(wholeSelector, signal),
+        variantSampleSet: await HospDiedAgeSampleData.fromApi(addDefaultHostAndQc(variantSelector), signal),
+        wholeSampleSet: await HospDiedAgeSampleData.fromApi(addDefaultHostAndQc(wholeSelector), signal),
         field: encoded.field,
         variantName: variantSelector.variant?.pangoLineage ?? 'unnamed variant',
         extendedMetrics: encoded.extendedMetrics,

--- a/src/widgets/MetadataAvailabilityChartWidget.ts
+++ b/src/widgets/MetadataAvailabilityChartWidget.ts
@@ -8,6 +8,7 @@ import {
 import { MetadataAvailabilityChart, MetadataAvailabilityChartProps } from './MetadataAvailabilityChart';
 import { SamplingStrategy } from '../data/SamplingStrategy';
 import { DatelessCountrylessCountSampleData } from '../data/sample/DatelessCountrylessCountSampleDataset';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export const MetadataAvailabilityChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -15,11 +16,11 @@ export const MetadataAvailabilityChartWidget = new Widget(
     async (decoded: MetadataAvailabilityChartProps) => encodeLocationDateSelector(decoded.sampleSet.selector),
     async (encoded, signal) => ({
       sampleSet: await DatelessCountrylessCountSampleData.fromApi(
-        {
+        addDefaultHostAndQc({
           ...decodeLocationDateSelector(encoded),
           // TODO This is actually a bug. The sampling strategy filter should be applied
           samplingStrategy: SamplingStrategy.AllSamples,
-        },
+        }),
         signal
       ),
     })

--- a/src/widgets/SequencingIntensityChartWidget.ts
+++ b/src/widgets/SequencingIntensityChartWidget.ts
@@ -8,6 +8,7 @@ import { AsyncStatusTypes } from '../data/AsyncDataset';
 import { DateCountSampleData } from '../data/sample/DateCountSampleDataset';
 import { CaseCountAsyncDataset, CaseCountData } from '../data/CaseCountDataset';
 import { SamplingStrategy } from '../data/SamplingStrategy';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export const SequencingIntensityChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -22,11 +23,11 @@ export const SequencingIntensityChartWidget = new Widget(
       const selector = decodeLocationDateSelector(encoded);
       return {
         sequencingCounts: await DateCountSampleData.fromApi(
-          {
+          addDefaultHostAndQc({
             ...selector,
             // TODO This is actually a bug. The sampling strategy filter should be applied
             samplingStrategy: SamplingStrategy.AllSamples,
-          },
+          }),
           signal
         ),
         caseCounts: {

--- a/src/widgets/SequencingRepresentativenessChartWidget.ts
+++ b/src/widgets/SequencingRepresentativenessChartWidget.ts
@@ -13,6 +13,7 @@ import { CaseCountAsyncDataset, CaseCountData } from '../data/CaseCountDataset';
 import { AsyncStatusTypes } from '../data/AsyncDataset';
 import { SamplingStrategy } from '../data/SamplingStrategy';
 import { DatelessCountrylessCountSampleData } from '../data/sample/DatelessCountrylessCountSampleDataset';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export const SequencingRepresentativenessChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -28,11 +29,11 @@ export const SequencingRepresentativenessChartWidget = new Widget(
           status: AsyncStatusTypes.fulfilled,
         } as CaseCountAsyncDataset,
         sampleDataset: await DatelessCountrylessCountSampleData.fromApi(
-          {
+          addDefaultHostAndQc({
             ...decodeLocationDateSelector(encoded),
             // TODO This is actually a bug. The sampling strategy filter should be applied
             samplingStrategy: SamplingStrategy.AllSamples,
-          },
+          }),
           signal
         ),
       };

--- a/src/widgets/VariantAgeDistributionChartWidget.ts
+++ b/src/widgets/VariantAgeDistributionChartWidget.ts
@@ -8,6 +8,7 @@ import {
   LocationDateVariantSelectorEncodedSchema,
 } from '../data/LocationDateVariantSelector';
 import { AgeCountSampleData } from '../data/sample/AgeCountSampleDataset';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export const VariantAgeDistributionChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -21,8 +22,8 @@ export const VariantAgeDistributionChartWidget = new Widget(
         variant: undefined,
       };
       return {
-        variantSampleSet: await AgeCountSampleData.fromApi(variantSelector, signal),
-        wholeSampleSet: await AgeCountSampleData.fromApi(wholeSelector, signal),
+        variantSampleSet: await AgeCountSampleData.fromApi(addDefaultHostAndQc(variantSelector), signal),
+        wholeSampleSet: await AgeCountSampleData.fromApi(addDefaultHostAndQc(wholeSelector), signal),
       };
     }
   ),

--- a/src/widgets/VariantDivisionDistributionChartWidget.ts
+++ b/src/widgets/VariantDivisionDistributionChartWidget.ts
@@ -11,6 +11,7 @@ import {
   VariantDivisionDistributionChartProps,
 } from './VariantDivisionDistributionChart';
 import { DivisionCountSampleData } from '../data/sample/DivisionCountSampleDataset';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export const VariantDivisionDistributionChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -24,8 +25,8 @@ export const VariantDivisionDistributionChartWidget = new Widget(
         variant: undefined,
       };
       return {
-        variantSampleSet: await DivisionCountSampleData.fromApi(variantSelector, signal),
-        wholeSampleSet: await DivisionCountSampleData.fromApi(wholeSelector, signal),
+        variantSampleSet: await DivisionCountSampleData.fromApi(addDefaultHostAndQc(variantSelector), signal),
+        wholeSampleSet: await DivisionCountSampleData.fromApi(addDefaultHostAndQc(wholeSelector), signal),
       };
     }
   ),

--- a/src/widgets/VariantInternationalComparisonChartWidget.ts
+++ b/src/widgets/VariantInternationalComparisonChartWidget.ts
@@ -11,6 +11,7 @@ import {
 } from './VariantInternationalComparisonChart';
 import * as zod from 'zod';
 import { CountryDateCountSampleData } from '../data/sample/CountryDateCountSampleDataset';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export const VariantInternationalComparisonChartWidget = new Widget(
   new AsyncZodQueryEncoder(
@@ -31,8 +32,14 @@ export const VariantInternationalComparisonChartWidget = new Widget(
         variant: undefined,
       };
       return {
-        variantInternationalSampleSet: await CountryDateCountSampleData.fromApi(variantSelector, signal),
-        wholeInternationalSampleSet: await CountryDateCountSampleData.fromApi(wholeSelector, signal),
+        variantInternationalSampleSet: await CountryDateCountSampleData.fromApi(
+          addDefaultHostAndQc(variantSelector),
+          signal
+        ),
+        wholeInternationalSampleSet: await CountryDateCountSampleData.fromApi(
+          addDefaultHostAndQc(wholeSelector),
+          signal
+        ),
         preSelectedCountries: encoded.countries,
         logScale: encoded.logScale,
       };

--- a/src/widgets/VariantTimeDistributionChartWidget.ts
+++ b/src/widgets/VariantTimeDistributionChartWidget.ts
@@ -9,6 +9,7 @@ import {
 } from '../data/LocationDateVariantSelector';
 import { DateCountSampleData, DateCountSampleDataset } from '../data/sample/DateCountSampleDataset';
 import { VariantTimeDistributionLineChart } from './VariantTimeDistributionLineChart';
+import { addDefaultHostAndQc } from '../data/HostAndQcSelector';
 
 export type VariantTimeDistributionChartProps = {
   variantSampleSet: DateCountSampleDataset;
@@ -27,8 +28,8 @@ export const VariantTimeDistributionChartWidget = new Widget(
         variant: undefined,
       };
       return {
-        variantSampleSet: await DateCountSampleData.fromApi(variantSelector, signal),
-        wholeSampleSet: await DateCountSampleData.fromApi(wholeSelector, signal),
+        variantSampleSet: await DateCountSampleData.fromApi(addDefaultHostAndQc(variantSelector), signal),
+        wholeSampleSet: await DateCountSampleData.fromApi(addDefaultHostAndQc(wholeSelector), signal),
       };
     }
   ),


### PR DESCRIPTION
This PR introduces advanced filters. It is now possible to filter the sequences by their host (default is human-only) and by (Nextclade) QC scores.

It closes #445

---

## Screenshots

![image](https://user-images.githubusercontent.com/18666552/161250342-12a2c8ec-6828-489c-9029-bd926bc0947b.png)

![image](https://user-images.githubusercontent.com/18666552/161250365-5f7679eb-eff9-4c1f-94c6-5178b76e2a9c.png)
