### PR TITLE
Pass 5k instead of 1k seqs to Usher, use 5k instead of 1k sequences in context

### DIFF
--- a/src/services/external-integrations/UsherIntegration.ts
+++ b/src/services/external-integrations/UsherIntegration.ts
@@ -7,7 +7,7 @@ import { LapisSelector } from '../../data/LapisSelector';
 const usherUrl =
   'https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&phyloPlaceTree=hgPhyloPlaceData/wuhCor1' +
   '/public.plusGisaid.latest.masked.pb&subtreeSize=5000&remoteFile=';
-const defaultOrderAndLimit: OrderAndLimitConfig = { orderBy: 'random', limit: 5000 };
+const defaultOrderAndLimit: OrderAndLimitConfig = { orderBy: 'random', limit: 1000 };
 
 export class UsherIntegration implements Integration {
   name = 'UShER';

--- a/src/services/external-integrations/UsherIntegration.ts
+++ b/src/services/external-integrations/UsherIntegration.ts
@@ -7,7 +7,7 @@ import { LapisSelector } from '../../data/LapisSelector';
 const usherUrl =
   'https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&phyloPlaceTree=hgPhyloPlaceData/wuhCor1' +
   '/public.plusGisaid.latest.masked.pb&subtreeSize=1000&remoteFile=';
-const defaultOrderAndLimit: OrderAndLimitConfig = { orderBy: 'random', limit: 1000 };
+const defaultOrderAndLimit: OrderAndLimitConfig = { orderBy: 'random', limit: 5000 };
 
 export class UsherIntegration implements Integration {
   name = 'UShER';

--- a/src/services/external-integrations/UsherIntegration.ts
+++ b/src/services/external-integrations/UsherIntegration.ts
@@ -6,7 +6,7 @@ import { LapisSelector } from '../../data/LapisSelector';
 
 const usherUrl =
   'https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&phyloPlaceTree=hgPhyloPlaceData/wuhCor1' +
-  '/public.plusGisaid.latest.masked.pb&subtreeSize=1000&remoteFile=';
+  '/public.plusGisaid.latest.masked.pb&subtreeSize=5000&remoteFile=';
 const defaultOrderAndLimit: OrderAndLimitConfig = { orderBy: 'random', limit: 5000 };
 
 export class UsherIntegration implements Integration {


### PR DESCRIPTION
Usher is capable of making a tree with up to 5000 sequences. Currently, we tell Usher to make a tree with 1000, which is unnecessarily restrictive and limits the usefulness without good reason - I always use Usher with 5k context sequences for my usage and never encounter any problems.

Maybe @AngieHinrichs can advise if there are any issues with using 5k instead of 1k sequences. 

Actually, it turns out I misunderstood. This PR now shares 5k sequences to Usher which Usher amazingly has no problem dealing with - I managed to get the entire BA.2.3.20* tree with ~5k sequences. Hats off!

What I actually wanted to achieve is to get more _context_ sequences, but this is cool as well. @AngieHinrichs, how can we include more context samples? The number box here of samples to show per tree? It's actually nice to be able to get trees bigger than that (in my case 6.5k here)
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/25161793/210408520-e3a8b363-a855-4975-849a-02ce564ccf98.png">

<img width="2099" alt="image" src="https://user-images.githubusercontent.com/25161793/210408580-756cbbfc-549a-44d5-8db2-48a40bfc4415.png">
