### PR TITLE
get rid of warnings in console while executing the tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "@types/react-router-hash-link": "^2.4.2",
         "all-contributors-cli": "^6.20.0",
         "autoprefixer": "^10.4.13",
+        "cross-env": "^7.0.3",
         "eslint": "^8.21.0",
         "eslint-plugin-unused-imports": "^2.0.0",
         "jest-canvas-mock": "^2.3.1",
@@ -8349,6 +8350,24 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
       "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA=="
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -33023,6 +33042,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
       "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA=="
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-fetch": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "cross-env REACT_APP_IS_TESTING=true react-scripts test",
     "eject": "react-scripts eject",
     "format": "prettier --write . && npx eslint . --fix",
     "check-format": "prettier --check .",
@@ -168,6 +168,7 @@
     "@types/react-router-hash-link": "^2.4.2",
     "all-contributors-cli": "^6.20.0",
     "autoprefixer": "^10.4.13",
+    "cross-env": "^7.0.3",
     "eslint": "^8.21.0",
     "eslint-plugin-unused-imports": "^2.0.0",
     "jest-canvas-mock": "^2.3.1",


### PR DESCRIPTION
The tests complained that the ExportManager was not set via the context provider.