### PR TITLE
Fix warnings in console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "@types/react-select": "^4.0.15",
         "@types/react-simple-maps": "^1.0.3",
         "@types/react-test-renderer": "^17.0.1",
-        "@types/recharts": "^1.8.19",
         "@types/styled-components": "^5.1.7",
         "assert": "^2.0.0",
         "bootstrap": "^4.5.3",
@@ -5765,28 +5764,6 @@
       "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/recharts": {
-      "version": "1.8.23",
-      "resolved": "https://registry.npmjs.org/@types/recharts/-/recharts-1.8.23.tgz",
-      "integrity": "sha512-O/mIPm9f6dwRWfenOI3GQwsGta3x1YWjwqXOCZqC0MATQ6C+A+Jc8VxFnSUr4N3uYv64zkq90RwXFaMNbhJKvg==",
-      "dependencies": {
-        "@types/d3-shape": "^1",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/recharts/node_modules/@types/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
-    },
-    "node_modules/@types/recharts/node_modules/@types/d3-shape": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
-      "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
-      "dependencies": {
-        "@types/d3-path": "^1"
       }
     },
     "node_modules/@types/resize-observer-browser": {
@@ -31035,30 +31012,6 @@
       "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
       "requires": {
         "@types/react": "*"
-      }
-    },
-    "@types/recharts": {
-      "version": "1.8.23",
-      "resolved": "https://registry.npmjs.org/@types/recharts/-/recharts-1.8.23.tgz",
-      "integrity": "sha512-O/mIPm9f6dwRWfenOI3GQwsGta3x1YWjwqXOCZqC0MATQ6C+A+Jc8VxFnSUr4N3uYv64zkq90RwXFaMNbhJKvg==",
-      "requires": {
-        "@types/d3-shape": "^1",
-        "@types/react": "*"
-      },
-      "dependencies": {
-        "@types/d3-path": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
-          "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
-        },
-        "@types/d3-shape": {
-          "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.8.tgz",
-          "integrity": "sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==",
-          "requires": {
-            "@types/d3-path": "^1"
-          }
-        }
       }
     },
     "@types/resize-observer-browser": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/react-select": "^4.0.15",
     "@types/react-simple-maps": "^1.0.3",
     "@types/react-test-renderer": "^17.0.1",
-    "@types/recharts": "^1.8.19",
     "@types/styled-components": "^5.1.7",
     "assert": "^2.0.0",
     "bootstrap": "^4.5.3",

--- a/src/components/FocusVariantHeaderControls.tsx
+++ b/src/components/FocusVariantHeaderControls.tsx
@@ -145,7 +145,7 @@ export const FocusVariantHeaderControls = React.memo(({ selector }: Props): JSX.
           open={openSequence}
           onClose={() => handleClose(true)}
         >
-          <MenuItem disableRipple>
+          <MenuItem disableRipple key='sequenceList'>
             <DownloadIcon />
             <ExternalLink url={listLink ?? ''}>Sequence list</ExternalLink>
           </MenuItem>
@@ -153,18 +153,18 @@ export const FocusVariantHeaderControls = React.memo(({ selector }: Props): JSX.
           <Divider sx={{ my: 0.5 }} />
 
           {sequenceDataSource === 'gisaid' && (
-            <MenuItem disableRipple>
+            <MenuItem disableRipple key='gisaid'>
               <ExternalLink url={listLink2 ?? ''}>GISAID list</ExternalLink>
             </MenuItem>
           )}
 
           {sequenceDataSource === 'open' && (
             <>
-              <MenuItem disableRipple>
+              <MenuItem disableRipple key='fasta'>
                 <ExternalLink url={fastaLink ?? ''}>FASTA</ExternalLink>
               </MenuItem>
 
-              <MenuItem disableRipple>
+              <MenuItem disableRipple key='fastaAligned'>
                 <ExternalLink url={alignedFastaLink ?? ''}>FASTA (aligned)</ExternalLink>
               </MenuItem>
             </>
@@ -193,7 +193,9 @@ export const FocusVariantHeaderControls = React.memo(({ selector }: Props): JSX.
           {integrations.map(
             integration =>
               integration.isAvailable(selector) && (
-                <MenuItem onClick={() => integration.open(selector)}> {integration.name}</MenuItem>
+                <MenuItem onClick={() => integration.open(selector)} key={integration.name}>
+                  {integration.name}
+                </MenuItem>
               )
           )}
         </Menu>

--- a/src/components/GridPlot/SequencesOverTimeGridInner.tsx
+++ b/src/components/GridPlot/SequencesOverTimeGridInner.tsx
@@ -6,6 +6,7 @@ import { GroupedData } from '../../data/transform/transform';
 import { EntryDateCountWithProportions } from './SequencesOverTimeGrid';
 import { HtmlPortalNode, InPortal } from 'react-reverse-portal';
 import { AxisPortals, TwoValuesXAxis, TwoValuesYAxis } from './common';
+import { TooltipSideEffect } from '../../widgets/Tooltip';
 
 type PlotEntry = {
   dateAsNumber: number;
@@ -93,14 +94,20 @@ export const SequencesOverTimeGridInner = ({ data, portals, axisPortals, plotWid
                 <Tooltip
                   active={false}
                   cursor={false}
-                  content={e => {
-                    if (e.active && e.payload !== undefined) {
-                      const newActive = e.payload[0].payload;
-                      if (active === undefined || active !== newActive.dateAsNumber) {
-                        setActive(newActive.dateAsNumber);
-                      }
-                    }
-                    return <></>;
+                  content={tooltipProps => {
+                    return (
+                      <TooltipSideEffect
+                        tooltipProps={tooltipProps}
+                        sideEffect={tooltipProps => {
+                          if (tooltipProps.active && tooltipProps.payload !== undefined) {
+                            const newActive = tooltipProps.payload[0].payload;
+                            if (active === undefined || active !== newActive.dateAsNumber) {
+                              setActive(newActive.dateAsNumber);
+                            }
+                          }
+                        }}
+                      />
+                    );
                   }}
                 />
                 {active && (

--- a/src/components/VariantMutationsTimelines.tsx
+++ b/src/components/VariantMutationsTimelines.tsx
@@ -315,7 +315,7 @@ const Plot = ({ data, logitScale, colorScale }: PlotProps) => {
         }}
       >
         {data.mutations.map(({ mutation, proportions, counts }, i) => (
-          <>
+          <React.Fragment key={mutation}>
             <div
               className='text-right pr-4'
               key={mutation}
@@ -340,7 +340,7 @@ const Plot = ({ data, logitScale, colorScale }: PlotProps) => {
                 />
               </div>
             ))}
-          </>
+          </React.Fragment>
         ))}
       </div>
       <div className='flex justify-between'>
@@ -406,7 +406,7 @@ const ProportionBox = ({
   }
 
   const popover = (
-    <Popover id='popover-basic' style={{ maxWidth: '600px' }}>
+    <Popover id='popover-basic' style={{ maxWidth: '600px', margin: 'unset' }}>
       <Popover.Body>
         <div className='font-bold'>
           Week {week.isoWeek}, {week.isoYear} ({week.firstDay.string})

--- a/src/helpers/ui.tsx
+++ b/src/helpers/ui.tsx
@@ -141,7 +141,7 @@ export const PipeDividedOptionsButtons = <T extends unknown>({
   return (
     <div>
       {options.map(({ label, value }, index) => (
-        <>
+        <React.Fragment key={index}>
           {index > 0 && (
             <span key={'sep-' + index} className='mx-2'>
               |
@@ -154,7 +154,7 @@ export const PipeDividedOptionsButtons = <T extends unknown>({
           >
             {label}
           </span>
-        </>
+        </React.Fragment>
       ))}
     </div>
   );

--- a/src/models/huismanScire2021Re/HuismanScire2021ReChart.tsx
+++ b/src/models/huismanScire2021Re/HuismanScire2021ReChart.tsx
@@ -15,6 +15,7 @@ import React, { useMemo, useState } from 'react';
 import { formatDate } from '../../widgets/VariantTimeDistributionLineChartInner';
 import { maxYAxis } from '../../helpers/max-y-axis';
 import { getTicks } from '../../helpers/ticks';
+import { TooltipSideEffect } from '../../widgets/Tooltip';
 
 type Props = {
   data: HuismanScire2021ReResult;
@@ -73,14 +74,20 @@ export const HuismanScire2021ReChart = ({ data }: Props) => {
               />
               <Tooltip
                 active={false}
-                content={e => {
-                  if (e.active && e.payload !== undefined) {
-                    const newActive = e.payload[0].payload;
-                    if (active === undefined || active.date.getTime() !== newActive.date.getTime()) {
-                      setActive(newActive);
-                    }
-                  }
-                  return <></>;
+                content={tooltipProps => {
+                  return (
+                    <TooltipSideEffect
+                      tooltipProps={tooltipProps}
+                      sideEffect={tooltipProps => {
+                        if (tooltipProps.active && tooltipProps.payload !== undefined) {
+                          const newActive = tooltipProps.payload[0].payload;
+                          if (active === undefined || active.date.getTime() !== newActive.date.getTime()) {
+                            setActive(newActive);
+                          }
+                        }
+                      }}
+                    />
+                  );
                 }}
               />
               <Area

--- a/src/models/wasteWater/WasteWaterTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterTimeChart.tsx
@@ -4,6 +4,7 @@ import Metric, { MetricsWrapper } from '../../widgets/Metrics';
 import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { WasteWaterTimeEntry, WasteWaterTimeseriesSummaryDataset } from './types';
 import { getTicks } from '../../helpers/ticks';
+import { TooltipSideEffect } from '../../widgets/Tooltip';
 
 export function formatDate(date: number) {
   const d = new Date(date);
@@ -55,17 +56,23 @@ export const WasteWaterTimeChart = React.memo(({ data }: Props): JSX.Element => 
               <YAxis />
               <Tooltip
                 active={false}
-                content={e => {
-                  if (e.active && e.payload !== undefined) {
-                    const newActive = e.payload[0].payload;
-                    if (active === undefined || active.date !== newActive.date) {
-                      setActive(newActive);
-                    }
-                  }
-                  if (!e.active) {
-                    setActive(undefined);
-                  }
-                  return <></>;
+                content={tooltipProps => {
+                  return (
+                    <TooltipSideEffect
+                      tooltipProps={tooltipProps}
+                      sideEffect={tooltipProps => {
+                        if (tooltipProps.active && tooltipProps.payload !== undefined) {
+                          const newActive = tooltipProps.payload[0].payload;
+                          if (active === undefined || active.date !== newActive.date) {
+                            setActive(newActive);
+                          }
+                        }
+                        if (!tooltipProps.active) {
+                          setActive(undefined);
+                        }
+                      }}
+                    />
+                  );
                 }}
               />
               <Area

--- a/src/widgets/EstimatedCasesChartInner.tsx
+++ b/src/widgets/EstimatedCasesChartInner.tsx
@@ -10,6 +10,7 @@ import DownloadWrapper from './DownloadWrapper';
 import { Alert, AlertVariant } from '../helpers/ui';
 import { maxYAxis } from '../helpers/max-y-axis';
 import { PprettyRequest } from '../data/ppretty/ppretty-request';
+import { TooltipSideEffect } from './Tooltip';
 
 export type EstimatedCasesTimeEntry = {
   date: UnifiedDay;
@@ -122,14 +123,23 @@ export const EstimatedCasesChartInner = React.memo(
                   <YAxis domain={[0, maxYAxis(yMax, yMax, 5)]} allowDataOverflow={true} scale='linear' />
                   <Tooltip
                     active={false}
-                    content={e => {
-                      if (e.active && e.payload !== undefined) {
-                        const newActive = e.payload[0].payload;
-                        if (active === undefined || active.date.getTime() !== newActive.date.getTime()) {
-                          setActive(newActive);
-                        }
-                      }
-                      return <></>;
+                    content={tooltipProps => {
+                      return (
+                        <TooltipSideEffect
+                          tooltipProps={tooltipProps}
+                          sideEffect={tooltipProps => {
+                            if (tooltipProps.active && tooltipProps.payload !== undefined) {
+                              const newActive = tooltipProps.payload[0].payload;
+                              if (
+                                active === undefined ||
+                                active.date.getTime() !== newActive.date.getTime()
+                              ) {
+                                setActive(newActive);
+                              }
+                            }
+                          }}
+                        />
+                      );
                     }}
                   />
                   <Area

--- a/src/widgets/MetadataAvailabilityChart.tsx
+++ b/src/widgets/MetadataAvailabilityChart.tsx
@@ -4,6 +4,7 @@ import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 
 import Metrics, { MetricsWrapper } from './Metrics';
 import { kFormat } from '../helpers/number';
 import { DatelessCountrylessCountSampleDataset } from '../data/sample/DatelessCountrylessCountSampleDataset';
+import { TooltipSideEffect } from './Tooltip';
 
 export type MetadataAvailabilityChartProps = {
   sampleSet: DatelessCountrylessCountSampleDataset;
@@ -81,17 +82,23 @@ export const MetadataAvailabilityChart = ({ sampleSet }: MetadataAvailabilityCha
                 <Tooltip
                   active={false}
                   cursor={false}
-                  content={e => {
-                    if (e.active && e.payload !== undefined) {
-                      const newActive = e.payload[0].payload;
-                      if (active?.attributeLabel !== newActive.attributeLabel) {
-                        setActive(newActive);
-                      }
-                    }
-                    if (!e.active) {
-                      setActive(undefined);
-                    }
-                    return <></>;
+                  content={tooltipProps => {
+                    return (
+                      <TooltipSideEffect
+                        tooltipProps={tooltipProps}
+                        sideEffect={tooltipProps => {
+                          if (tooltipProps.active && tooltipProps.payload !== undefined) {
+                            const newActive = tooltipProps.payload[0].payload;
+                            if (active?.attributeLabel !== newActive.attributeLabel) {
+                              setActive(newActive);
+                            }
+                          }
+                          if (!tooltipProps.active) {
+                            setActive(undefined);
+                          }
+                        }}
+                      />
+                    );
                   }}
                 />
               </BarChart>

--- a/src/widgets/SequencingIntensityChartInner.tsx
+++ b/src/widgets/SequencingIntensityChartInner.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ChartAndMetrics } from './Metrics';
-import { BarChart, XAxis, YAxis, Bar, Cell, ResponsiveContainer, CartesianGrid, Tooltip } from 'recharts';
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { colors, TimeTick } from './common';
 import { kFormat } from '../helpers/number';
+import { SetCurrentDataSideEffect } from './Tooltip';
 
 const CHART_MARGIN_RIGHT = 30;
 const CHART_MARGIN_BOTTOM = 0;
@@ -120,11 +121,10 @@ export const SequencingIntensityChartInner = React.memo(
             <Tooltip
               active={false}
               cursor={false}
-              content={(e: any) => {
-                if (e?.payload.length > 0) {
-                  setCurrentData(e.payload[0].payload);
-                }
-                return <></>;
+              content={tooltipProps => {
+                return (
+                  <SetCurrentDataSideEffect tooltipProps={tooltipProps} setCurrentData={setCurrentData} />
+                );
               }}
             />
           </BarChart>

--- a/src/widgets/SequencingRepresentativenessChart.tsx
+++ b/src/widgets/SequencingRepresentativenessChart.tsx
@@ -10,6 +10,7 @@ import Loader from '../components/Loader';
 import { CaseCountAsyncDataset } from '../data/CaseCountDataset';
 import { DatelessCountrylessCountSampleDataset } from '../data/sample/DatelessCountrylessCountSampleDataset';
 import { DatelessCountrylessCountSampleEntry } from '../data/sample/DatelessCountrylessCountSampleEntry';
+import { TooltipSideEffect } from './Tooltip';
 
 export type SequencingRepresentativenessChartProps = {
   caseDataset: CaseCountAsyncDataset;
@@ -164,17 +165,23 @@ export const SequencingRepresentativenessChart = React.memo(
                         <Tooltip
                           active={false}
                           cursor={false}
-                          content={e => {
-                            if (e.active && e.payload !== undefined) {
-                              const newActive = e.payload[0].payload;
-                              if (active?.key !== newActive.key) {
-                                setActive(newActive);
-                              }
-                            }
-                            if (!e.active) {
-                              setActive(undefined);
-                            }
-                            return <></>;
+                          content={tooltipProps => {
+                            return (
+                              <TooltipSideEffect
+                                tooltipProps={tooltipProps}
+                                sideEffect={tooltipProps => {
+                                  if (tooltipProps.active && tooltipProps.payload !== undefined) {
+                                    const newActive = tooltipProps.payload[0].payload;
+                                    if (active?.key !== newActive.key) {
+                                      setActive(newActive);
+                                    }
+                                  }
+                                  if (!tooltipProps.active) {
+                                    setActive(undefined);
+                                  }
+                                }}
+                              />
+                            );
                           }}
                         />
                       </BarChart>

--- a/src/widgets/Tooltip.tsx
+++ b/src/widgets/Tooltip.tsx
@@ -1,0 +1,36 @@
+import { TooltipProps } from 'recharts';
+import { NameType, ValueType } from 'recharts/src/component/DefaultTooltipContent';
+import React, { useEffect } from 'react';
+import { Payload } from 'recharts/types/component/DefaultTooltipContent';
+
+export function SetCurrentDataSideEffect<Data>({
+  tooltipProps,
+  setCurrentData,
+}: {
+  tooltipProps: TooltipProps<ValueType, NameType>;
+  setCurrentData: (data: Data) => void;
+}) {
+  return (
+    <TooltipSideEffect
+      tooltipProps={tooltipProps}
+      sideEffect={tooltipProps => {
+        if (tooltipProps?.payload?.length === undefined || tooltipProps.payload.length > 0) {
+          setCurrentData((tooltipProps.payload as Payload<any, any>[])[0].payload);
+        }
+      }}
+    />
+  );
+}
+
+export function TooltipSideEffect({
+  tooltipProps,
+  sideEffect,
+}: {
+  tooltipProps: TooltipProps<ValueType, NameType>;
+  sideEffect: (data: TooltipProps<ValueType, NameType>) => void;
+}) {
+  useEffect(() => {
+    sideEffect(tooltipProps);
+  }, [tooltipProps, sideEffect]);
+  return null;
+}

--- a/src/widgets/VariantAgeDistributionChart.tsx
+++ b/src/widgets/VariantAgeDistributionChart.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChartAndMetrics } from './Metrics';
-import { BarChart, XAxis, YAxis, Bar, Cell, ResponsiveContainer, CartesianGrid, Tooltip } from 'recharts';
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { colors } from './common';
 import { AgeCountSampleData, AgeCountSampleDataset } from '../data/sample/AgeCountSampleDataset';
 import { fillFromPrimitiveMap, possibleAgeKeys } from '../helpers/fill-missing';
 import { useResizeDetector } from 'react-resize-detector';
 import DownloadWrapper from './DownloadWrapper';
 import { maxYAxis } from '../helpers/max-y-axis';
+import { SetCurrentDataSideEffect } from './Tooltip';
 
 const CHART_MARGIN_RIGHT = 15;
 
@@ -177,11 +178,10 @@ export const VariantAgeDistributionChart = React.memo(
                 <Tooltip
                   active={false}
                   cursor={false}
-                  content={(e: any) => {
-                    if (e?.payload.length > 0) {
-                      setCurrentData(e.payload[0].payload);
-                    }
-                    return <></>;
+                  content={tooltipProps => {
+                    return (
+                      <SetCurrentDataSideEffect tooltipProps={tooltipProps} setCurrentData={setCurrentData} />
+                    );
                   }}
                 />
               </BarChart>

--- a/src/widgets/VariantTimeDistributionBarChart.tsx
+++ b/src/widgets/VariantTimeDistributionBarChart.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChartAndMetrics } from './Metrics';
-import { BarChart, XAxis, YAxis, Bar, Cell, ResponsiveContainer, CartesianGrid, Tooltip } from 'recharts';
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { colors, TimeTick } from './common';
 import { DateCountSampleData } from '../data/sample/DateCountSampleDataset';
 import { fillAndFilterFromWeeklyMap } from '../helpers/fill-missing';
@@ -9,6 +9,7 @@ import { VariantTimeDistributionChartProps } from './VariantTimeDistributionChar
 import { maxYAxis } from '../helpers/max-y-axis';
 import { ButtonToolbar } from 'react-bootstrap';
 import { Button, ButtonVariant } from '../helpers/ui';
+import { SetCurrentDataSideEffect } from './Tooltip';
 
 const CHART_MARGIN_RIGHT = 30;
 const CHART_MARGIN_BOTTOM = 10;
@@ -192,11 +193,10 @@ export const VariantTimeDistributionBarChart = React.memo(
               <Tooltip
                 active={false}
                 cursor={false}
-                content={(e: any) => {
-                  if (e?.payload.length > 0) {
-                    setCurrentData(e.payload[0].payload);
-                  }
-                  return <></>;
+                content={tooltipProps => {
+                  return (
+                    <SetCurrentDataSideEffect tooltipProps={tooltipProps} setCurrentData={setCurrentData} />
+                  );
                 }}
               />
             </BarChart>

--- a/src/widgets/VariantTimeDistributionLineChartInner.tsx
+++ b/src/widgets/VariantTimeDistributionLineChartInner.tsx
@@ -226,7 +226,7 @@ export const VariantTimeDistributionLineChartInner = React.memo(
                 }}
               >
                 <FormControlLabel
-                  control={<Checkbox defaultChecked checked={logScale} onChange={toggleLogScale} />}
+                  control={<Checkbox checked={logScale} onChange={toggleLogScale} />}
                   label='Log scale'
                 />
               </FormGroup>

--- a/src/widgets/VariantTimeDistributionLineChartInner.tsx
+++ b/src/widgets/VariantTimeDistributionLineChartInner.tsx
@@ -12,6 +12,7 @@ import { ButtonToolbar, ButtonGroup } from 'react-bootstrap';
 import { Alert, AlertVariant, Button, ButtonVariant } from '../helpers/ui';
 import { Checkbox, FormControlLabel, FormGroup } from '@mui/material';
 import { PprettyRequest } from '../data/ppretty/ppretty-request';
+import { TooltipSideEffect } from './Tooltip';
 
 export type VariantTimeDistributionLineChartEntry = {
   date: UnifiedDay;
@@ -265,16 +266,28 @@ export const VariantTimeDistributionLineChartInner = React.memo(
                   />
                   <Tooltip
                     active={false}
-                    content={e => {
-                      if (e.active && e.payload !== undefined) {
-                        if (e.payload[0] !== undefined && e.payload[0].payload !== undefined) {
-                          const newActive = e.payload[0].payload;
-                          if (active === undefined || active.date.getTime() !== newActive.date.getTime()) {
-                            setActive(newActive);
-                          }
-                        }
-                      }
-                      return <></>;
+                    content={tooltipProps => {
+                      return (
+                        <TooltipSideEffect
+                          tooltipProps={tooltipProps}
+                          sideEffect={tooltipProps => {
+                            if (tooltipProps.active && tooltipProps.payload !== undefined) {
+                              if (
+                                tooltipProps.payload[0] !== undefined &&
+                                tooltipProps.payload[0].payload !== undefined
+                              ) {
+                                const newActive = tooltipProps.payload[0].payload;
+                                if (
+                                  active === undefined ||
+                                  active.date.getTime() !== newActive.date.getTime()
+                                ) {
+                                  setActive(newActive);
+                                }
+                              }
+                            }
+                          }}
+                        />
+                      );
                     }}
                   />
                   {!absoluteNumbers && (

--- a/src/widgets/__tests__/__snapshots__/VariantTimeDistributionLineChart.test.tsx.snap
+++ b/src/widgets/__tests__/__snapshots__/VariantTimeDistributionLineChart.test.tsx.snap
@@ -90,7 +90,6 @@ exports[`<VariantTimeDistributionLineChart> dataset0 renders correctly 1`] = `
                 checked={false}
                 className="PrivateSwitchBase-input css-1m9pwf3"
                 data-indeterminate={false}
-                defaultChecked={true}
                 onChange={[Function]}
                 type="checkbox"
               />


### PR DESCRIPTION
Fixes: Check warnings in console #671 and #268

Could not reproduce #266 and #270.

Warning "componentWillReceiveProps has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details" still remains. It comes from "react-numeric-input". The library seems unmaintained and will probably not work with React 18.