### PR TITLE
Show what a recombinant alias stand for #585

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@sentry/tracing": "^6.16.1",
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.3",
+        "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^12.6.0",
         "@types/bootstrap": "^5.0.5",
         "@types/chroma-js": "^2.1.3",
@@ -4761,6 +4762,35 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/react/node_modules/@jest/types": {
@@ -21361,6 +21391,21 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -30196,6 +30241,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
       }
     },
     "@testing-library/user-event": {
@@ -42865,6 +42919,14 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@sentry/tracing": "^6.16.1",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^12.6.0",
     "@types/bootstrap": "^5.0.5",
     "@types/chroma-js": "^2.1.3",

--- a/src/components/VariantHeader.tsx
+++ b/src/components/VariantHeader.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import { PangoLineageAliasResolverService } from '../services/PangoLineageAliasResolverService';
-import { formatVariantDisplayName, VariantSelector } from '../data/VariantSelector';
+import React, { useMemo } from 'react';
+import { formatVariantDisplayName, getPangoLineage, VariantSelector } from '../data/VariantSelector';
+import { fetchPangoLineageRecombinant } from '../data/api';
+import { usePangoLineageFullName } from '../services/pangoLineageAlias';
+import { useQuery } from '../helpers/query-hook';
 
 export interface Props {
   variant: VariantSelector;
@@ -8,35 +10,52 @@ export interface Props {
   controls?: React.ReactChild | React.ReactChild[];
 }
 
-function useFullName(variant: VariantSelector) {
-  const [resolvedFullName, setResolvedFullName] = useState<string | undefined>();
+function useLineageDescriptionText(variant: VariantSelector) {
+  const lineageAliasText = useAliasText(variant);
+  const recombinationText = useRecombinantText(variant);
 
-  useEffect(() => {
-    let isSubscribed = true;
-    if (variant.pangoLineage === undefined && variant.nextcladePangoLineage === undefined) {
-      setResolvedFullName(undefined);
-      return;
-    }
-    const pangoLineage: string = variant.pangoLineage
-      ? variant.pangoLineage
-      : variant.nextcladePangoLineage
-      ? variant.nextcladePangoLineage
-      : '';
-    PangoLineageAliasResolverService.findFullName(pangoLineage).then(name => {
-      if (isSubscribed) {
-        setResolvedFullName(name);
+  if (lineageAliasText !== undefined) {
+    return lineageAliasText;
+  }
+  return recombinationText;
+}
+
+function useAliasText(variant: VariantSelector) {
+  const pangoLineage = getPangoLineage(variant);
+  const pangoLineageFullName = usePangoLineageFullName(pangoLineage);
+  if (pangoLineageFullName === undefined) {
+    return undefined;
+  }
+  return 'Alias for ' + pangoLineageFullName;
+}
+
+function useRecombinantText(variant: VariantSelector) {
+  const { data } = useQuery(fetchPangoLineageRecombinant, []);
+  return useMemo(() => {
+    if (data) {
+      const pangoLineage = getPangoLineage(variant);
+      const baseLineage = extractBaseLineage(pangoLineage);
+
+      const recombinant = data.find(pangoLineageRecombinant => {
+        return pangoLineageRecombinant.name === baseLineage;
+      });
+
+      if (recombinant) {
+        const recombinantTextPrefix =
+          baseLineage === pangoLineage ? 'Recombinant of ' : 'Child of recombinant of ';
+        return recombinantTextPrefix + [...new Set(recombinant.parents)].join(', ');
       }
-    });
-    return () => {
-      isSubscribed = false;
-    };
-  }, [variant.pangoLineage, variant.nextcladePangoLineage]);
+    }
+    return undefined;
+  }, [data, variant]);
+}
 
-  return resolvedFullName;
+function extractBaseLineage(variantName: String) {
+  return variantName.split('.')[0];
 }
 
 export const VariantHeader = ({ variant, titleSuffix, controls }: Props) => {
-  const resolvedFullName = useFullName(variant);
+  const lineageDescriptionText = useLineageDescriptionText(variant);
 
   return (
     <div className='pt-10 lg:pt-0 ml-1 md:ml-3 w-full relative'>
@@ -50,7 +69,7 @@ export const VariantHeader = ({ variant, titleSuffix, controls }: Props) => {
           </h1>
         </div>
       </div>
-      {resolvedFullName && <h3 className=' text-gray-500'>Alias for {resolvedFullName}</h3>}
+      {lineageDescriptionText && <h3 className=' text-gray-500'>{lineageDescriptionText}</h3>}
     </div>
   );
 };

--- a/src/components/VariantHeader.tsx
+++ b/src/components/VariantHeader.tsx
@@ -1,16 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { PangoLineageAliasResolverService } from '../services/PangoLineageAliasResolverService';
 import { formatVariantDisplayName, VariantSelector } from '../data/VariantSelector';
-import { DateRangeSelector } from '../data/DateRangeSelector';
 
 export interface Props {
-  dateRange: DateRangeSelector;
   variant: VariantSelector;
   titleSuffix?: React.ReactChild | React.ReactChild[];
   controls?: React.ReactChild | React.ReactChild[];
 }
 
-export const VariantHeader = ({ variant, titleSuffix, controls }: Props) => {
+function useFullName(variant: VariantSelector) {
   const [resolvedFullName, setResolvedFullName] = useState<string | undefined>();
 
   useEffect(() => {
@@ -33,6 +31,12 @@ export const VariantHeader = ({ variant, titleSuffix, controls }: Props) => {
       isSubscribed = false;
     };
   }, [variant.pangoLineage, variant.nextcladePangoLineage]);
+
+  return resolvedFullName;
+}
+
+export const VariantHeader = ({ variant, titleSuffix, controls }: Props) => {
+  const resolvedFullName = useFullName(variant);
 
   return (
     <div className='pt-10 lg:pt-0 ml-1 md:ml-3 w-full relative'>

--- a/src/components/VariantHeader.tsx
+++ b/src/components/VariantHeader.tsx
@@ -14,10 +14,7 @@ function useLineageDescriptionText(variant: VariantSelector) {
   const lineageAliasText = useAliasText(variant);
   const recombinationText = useRecombinantText(variant);
 
-  if (lineageAliasText !== undefined) {
-    return lineageAliasText;
-  }
-  return recombinationText;
+  return lineageAliasText ?? recombinationText;
 }
 
 function useAliasText(variant: VariantSelector) {
@@ -41,8 +38,9 @@ function useRecombinantText(variant: VariantSelector) {
       });
 
       if (recombinant) {
-        const recombinantTextPrefix =
-          baseLineage === pangoLineage ? 'Recombinant of ' : 'Child of recombinant of ';
+        const recombinantTextPrefix = pangoLineage.startsWith(baseLineage + '.')
+          ? 'Child of recombinant of '
+          : 'Recombinant of ';
         return recombinantTextPrefix + [...new Set(recombinant.parents)].join(', ');
       }
     }
@@ -51,7 +49,7 @@ function useRecombinantText(variant: VariantSelector) {
 }
 
 function extractBaseLineage(variantName: String) {
-  return variantName.split('.')[0];
+  return variantName.split('.')[0].split('*')[0];
 }
 
 export const VariantHeader = ({ variant, titleSuffix, controls }: Props) => {

--- a/src/components/__tests__/VariantHeader.test.tsx
+++ b/src/components/__tests__/VariantHeader.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { VariantHeader } from '../VariantHeader';
+import { PangoLineageAliasResolverService } from '../../services/PangoLineageAliasResolverService';
+
+const findFullNameMock = jest.fn();
+
+PangoLineageAliasResolverService.findFullName = findFullNameMock;
+
+describe('VariantHeader', () => {
+  beforeEach(() => {
+    findFullNameMock.mockReset();
+  });
+
+  test('should display variant name without alias', () => {
+    findFullNameMock.mockResolvedValueOnce(undefined);
+
+    render(<VariantHeader variant={{ pangoLineage: 'pango lineage' }} />);
+
+    expect(screen.getByText('PANGO LINEAGE')).toBeInTheDocument();
+    expect(screen.queryByText('Alias')).not.toBeInTheDocument();
+  });
+
+  test('should display the title suffix', () => {
+    findFullNameMock.mockResolvedValueOnce(undefined);
+
+    render(<VariantHeader variant={{ pangoLineage: 'pango lineage' }} titleSuffix={<>title suffix</>} />);
+
+    expect(screen.getByText('PANGO LINEAGE - title suffix')).toBeInTheDocument();
+  });
+
+  test('should display the controls', () => {
+    findFullNameMock.mockResolvedValueOnce(undefined);
+
+    render(<VariantHeader variant={{ pangoLineage: 'pango lineage' }} controls={<>some controls</>} />);
+
+    expect(screen.getByText('some controls')).toBeInTheDocument();
+  });
+
+  test('should display variant alias', async () => {
+    findFullNameMock.mockResolvedValueOnce('"variant alias"');
+
+    render(<VariantHeader variant={{ pangoLineage: 'pango lineage' }} controls={<>some controls</>} />);
+
+    expect(await screen.findByText('Alias for "variant alias"')).toBeInTheDocument();
+    expect(findFullNameMock).toHaveBeenCalledWith('pango lineage');
+  });
+});

--- a/src/components/__tests__/VariantHeader.test.tsx
+++ b/src/components/__tests__/VariantHeader.test.tsx
@@ -1,19 +1,24 @@
 import { render, screen } from '@testing-library/react';
 import { VariantHeader } from '../VariantHeader';
-import { PangoLineageAliasResolverService } from '../../services/PangoLineageAliasResolverService';
+import { useQuery } from '../../helpers/query-hook';
+import { usePangoLineageFullName } from '../../services/pangoLineageAlias';
 
-const findFullNameMock = jest.fn();
+jest.mock('../../services/pangoLineageAlias');
+const usePangoLineageFullNameMock = usePangoLineageFullName as jest.Mock;
 
-PangoLineageAliasResolverService.findFullName = findFullNameMock;
+jest.mock('../../helpers/query-hook');
+const useQueryMock = useQuery as jest.Mock;
 
 describe('VariantHeader', () => {
   beforeEach(() => {
-    findFullNameMock.mockReset();
+    usePangoLineageFullNameMock.mockReset();
+    usePangoLineageFullNameMock.mockReturnValue(undefined);
+
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue({ data: undefined });
   });
 
   test('should display variant name without alias', () => {
-    findFullNameMock.mockResolvedValueOnce(undefined);
-
     render(<VariantHeader variant={{ pangoLineage: 'pango lineage' }} />);
 
     expect(screen.getByText('PANGO LINEAGE')).toBeInTheDocument();
@@ -21,27 +26,53 @@ describe('VariantHeader', () => {
   });
 
   test('should display the title suffix', () => {
-    findFullNameMock.mockResolvedValueOnce(undefined);
-
     render(<VariantHeader variant={{ pangoLineage: 'pango lineage' }} titleSuffix={<>title suffix</>} />);
 
     expect(screen.getByText('PANGO LINEAGE - title suffix')).toBeInTheDocument();
   });
 
   test('should display the controls', () => {
-    findFullNameMock.mockResolvedValueOnce(undefined);
-
     render(<VariantHeader variant={{ pangoLineage: 'pango lineage' }} controls={<>some controls</>} />);
 
     expect(screen.getByText('some controls')).toBeInTheDocument();
   });
 
   test('should display variant alias', async () => {
-    findFullNameMock.mockResolvedValueOnce('"variant alias"');
+    usePangoLineageFullNameMock.mockReturnValue('FULLNAME.1.2');
 
-    render(<VariantHeader variant={{ pangoLineage: 'pango lineage' }} controls={<>some controls</>} />);
+    render(<VariantHeader variant={{ pangoLineage: 'SOMEALIAS' }} />);
 
-    expect(await screen.findByText('Alias for "variant alias"')).toBeInTheDocument();
-    expect(findFullNameMock).toHaveBeenCalledWith('pango lineage');
+    expect(await screen.findByText('Alias for FULLNAME.1.2')).toBeInTheDocument();
+    expect(usePangoLineageFullNameMock).toHaveBeenCalledWith('SOMEALIAS');
+  });
+
+  test('should display recombination alias', async () => {
+    useQueryMock.mockReturnValue({
+      data: [
+        {
+          name: 'XAA',
+          parents: ['BA.1*', 'BA.2*', 'BA.1*'],
+        },
+      ],
+    });
+
+    render(<VariantHeader variant={{ pangoLineage: 'XAA' }} />);
+
+    expect(await screen.findByText('Recombinant of BA.1*, BA.2*')).toBeInTheDocument();
+  });
+
+  test('should display recombinant alias of child of recombinant', async () => {
+    useQueryMock.mockReturnValue({
+      data: [
+        {
+          name: 'XAA',
+          parents: ['BA.1*', 'BA.2*', 'BA.1*'],
+        },
+      ],
+    });
+
+    render(<VariantHeader variant={{ pangoLineage: 'XAA.1.5' }} />);
+
+    expect(await screen.findByText('Child of recombinant of BA.1*, BA.2*')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/VariantHeader.test.tsx
+++ b/src/components/__tests__/VariantHeader.test.tsx
@@ -46,7 +46,7 @@ describe('VariantHeader', () => {
     expect(usePangoLineageFullNameMock).toHaveBeenCalledWith('SOMEALIAS');
   });
 
-  test('should display recombination alias', async () => {
+  test.each([['XAA'], ['XAA*']])('should display recombination alias for %s', async pangoLineage => {
     useQueryMock.mockReturnValue({
       data: [
         {
@@ -56,7 +56,7 @@ describe('VariantHeader', () => {
       ],
     });
 
-    render(<VariantHeader variant={{ pangoLineage: 'XAA' }} />);
+    render(<VariantHeader variant={{ pangoLineage }} />);
 
     expect(await screen.findByText('Recombinant of BA.1*, BA.2*')).toBeInTheDocument();
   });

--- a/src/data/PangoLineageRecombinant.tsx
+++ b/src/data/PangoLineageRecombinant.tsx
@@ -1,0 +1,4 @@
+export type PangoLineageRecombinant = {
+  name: string;
+  parents: string[];
+};

--- a/src/data/VariantSelector.ts
+++ b/src/data/VariantSelector.ts
@@ -275,3 +275,11 @@ export function transformToVariantQuery(selector: VariantSelector): string {
   }
   return components.join(' & ');
 }
+
+export function getPangoLineage(variant: VariantSelector) {
+  return variant.pangoLineage
+    ? variant.pangoLineage
+    : variant.nextcladePangoLineage
+    ? variant.nextcladePangoLineage
+    : '';
+}

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -8,6 +8,7 @@ import { AccountService } from '../services/AccountService';
 import { ReferenceGenomeInfo } from './ReferenceGenomeInfo';
 import { UserCountry } from './UserCountry';
 import { AddCollectionResponse, Collection } from './Collection';
+import { PangoLineageRecombinant } from './PangoLineageRecombinant';
 
 const HOST = process.env.REACT_APP_SERVER_HOST;
 
@@ -96,6 +97,15 @@ export async function fetchPangoLineageAliases(signal?: AbortSignal): Promise<Pa
     throw new Error('Error fetching pango lineage aliases');
   }
   return (await res.json()) as PangoLineageAlias[];
+}
+
+export async function fetchPangoLineageRecombinant(signal?: AbortSignal): Promise<PangoLineageRecombinant[]> {
+  const url = '/resource/pango-lineage-recombinant';
+  const res = await get(url, signal);
+  if (!res.ok) {
+    throw new Error('Error fetching pango lineage recombinants');
+  }
+  return (await res.json()) as PangoLineageRecombinant[];
 }
 
 export async function fetchCountryMapping(signal?: AbortSignal): Promise<CountryMapping[]> {

--- a/src/pages/DeepChen2021FitnessPage.tsx
+++ b/src/pages/DeepChen2021FitnessPage.tsx
@@ -110,7 +110,6 @@ export const DeepChen2021FitnessPage = () => {
 
   return makeLayout(
     <VariantHeader
-      dateRange={exploreUrl.dateRange}
       variant={exploreUrl.variants![0]}
       controls={
         <Link to={exploreUrl.getOverviewPageUrl()}>

--- a/src/pages/DeepHospitalizationDeathPage.tsx
+++ b/src/pages/DeepHospitalizationDeathPage.tsx
@@ -29,7 +29,6 @@ export const DeepHospitalizationDeathPage = () => {
 
   return makeLayout(
     <VariantHeader
-      dateRange={exploreUrl.dateRange}
       variant={exploreUrl.variants![0]}
       controls={
         <Link to={exploreUrl.getOverviewPageUrl()}>

--- a/src/pages/DeepInternationalComparisonPage.tsx
+++ b/src/pages/DeepInternationalComparisonPage.tsx
@@ -28,7 +28,6 @@ export const DeepInternationalComparisonPage = () => {
 
   return makeLayout(
     <VariantHeader
-      dateRange={exploreUrl.dateRange}
       variant={exploreUrl.variants![0]}
       controls={
         <Link to={exploreUrl.getOverviewPageUrl()}>

--- a/src/pages/DeepWastewaterPage.tsx
+++ b/src/pages/DeepWastewaterPage.tsx
@@ -15,7 +15,6 @@ export const DeepWastewaterPage = () => {
 
   return makeLayout(
     <VariantHeader
-      dateRange={exploreUrl.dateRange}
       variant={exploreUrl.variants![0]}
       controls={
         <Link to={exploreUrl.getOverviewPageUrl()}>

--- a/src/pages/FocusSinglePage.tsx
+++ b/src/pages/FocusSinglePage.tsx
@@ -340,7 +340,6 @@ export const FocusSinglePageContent = ({
   return (
     <>
       <VariantHeader
-        dateRange={ldvsSelector.dateRange!}
         variant={ldvsSelector.variant}
         controls={<FocusVariantHeaderControls selector={ldvsSelector} />}
       />

--- a/src/services/PangoLineageAliasResolverService.ts
+++ b/src/services/PangoLineageAliasResolverService.ts
@@ -11,13 +11,7 @@ export class PangoLineageAliasResolverService {
 
   static async findFullName(pangoLineage: string): Promise<string | undefined> {
     const aliases = await PangoLineageAliasResolverService.aliases;
-    pangoLineage = pangoLineage.toUpperCase();
-    for (let { alias, fullName } of aliases) {
-      if (pangoLineage.startsWith(alias + '.')) {
-        return fullName + pangoLineage.substr(alias.length);
-      }
-    }
-    return undefined;
+    return this.findFullNameInAliases(pangoLineage, aliases);
   }
 
   static findFullNameUnsafeSync(pangoLineage: string): string | undefined {
@@ -25,6 +19,10 @@ export class PangoLineageAliasResolverService {
     if (!aliases) {
       return undefined;
     }
+    return this.findFullNameInAliases(pangoLineage, aliases);
+  }
+
+  private static findFullNameInAliases(pangoLineage: string, aliases: PangoLineageAlias[]) {
     pangoLineage = pangoLineage.toUpperCase();
     for (let { alias, fullName } of aliases) {
       if (pangoLineage.startsWith(alias + '.')) {

--- a/src/services/__tests__/pangoLineageAlias.test.ts
+++ b/src/services/__tests__/pangoLineageAlias.test.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '../../helpers/query-hook';
+import { renderHook } from '@testing-library/react-hooks';
+import { usePangoLineageFullName, usePangoLineageWithAlias } from '../pangoLineageAlias';
+
+jest.mock('../../helpers/query-hook');
+const useQueryMock = useQuery as jest.Mock;
+
+describe('usePangoLineageFullName', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue([]);
+  });
+
+  test.each([
+    { expectedResult: undefined, data: [] },
+    { expectedResult: undefined, data: [{ alias: 'SOMEOTHERALIAS', fullName: 'FULLNAME.1.2.3' }] },
+    { expectedResult: undefined, data: undefined },
+    { expectedResult: 'FULLNAME.4.5.6.1.2.3', data: [{ alias: 'SOMEALIAS', fullName: 'FULLNAME.4.5.6' }] },
+    { expectedResult: undefined, data: [{ alias: 'SOMEALIASEXTENDED', fullName: 'FULLNAME.4.5.6' }] },
+  ])('$#: should return $expectedResult for $data available', ({ expectedResult, data }) => {
+    useQueryMock.mockReturnValue({ data });
+
+    const pangoLineage = 'SOMEALIAS.1.2.3';
+    const { result } = renderHook(() => usePangoLineageFullName(pangoLineage));
+
+    expect(result.current).toBe(expectedResult);
+  });
+
+  test('should return only alias if pangoLineage is alias', () => {
+    useQueryMock.mockReturnValue({ data: [{ alias: 'SOMEALIAS', fullName: 'FULLNAME.1.2.3' }] });
+
+    const pangoLineage = 'SOMEALIAS';
+    const { result } = renderHook(() => usePangoLineageFullName(pangoLineage));
+
+    expect(result.current).toBe('FULLNAME.1.2.3');
+  });
+});
+
+describe('usePangoLineageWithAlias', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue([]);
+  });
+
+  test.each([
+    { expectedResult: 'FULLNAME.4.5.6', data: [] },
+    { expectedResult: 'FULLNAME.4.5.6', data: undefined },
+    { expectedResult: 'ALIAS.6', data: [{ alias: 'ALIAS', fullName: 'FULLNAME.4.5' }] },
+  ])('$#: should return $expectedResult for $data available', ({ expectedResult, data }) => {
+    useQueryMock.mockReturnValue({ data });
+
+    const pangoLineage = 'FULLNAME.4.5.6';
+    const { result } = renderHook(() => usePangoLineageWithAlias(pangoLineage));
+
+    expect(result.current).toBe(expectedResult);
+  });
+});

--- a/src/services/pangoLineageAlias.ts
+++ b/src/services/pangoLineageAlias.ts
@@ -1,0 +1,40 @@
+import { fetchPangoLineageAliases } from '../data/api';
+import { PangoLineageAlias } from '../data/PangoLineageAlias';
+import { useQuery } from '../helpers/query-hook';
+
+export function usePangoLineageFullName(pangoLineage: string) {
+  const { data } = useQuery(fetchPangoLineageAliases, []);
+
+  if (data === undefined) {
+    return undefined;
+  }
+
+  pangoLineage = pangoLineage.toUpperCase();
+  const pangoLineagePrefix = pangoLineage.split('.')[0];
+
+  const prefixFullName = data.find(pangoLineage => {
+    return pangoLineage.alias === pangoLineagePrefix;
+  })?.fullName;
+
+  if (prefixFullName === undefined) {
+    return undefined;
+  }
+
+  return prefixFullName + pangoLineage.substring(pangoLineagePrefix.length);
+}
+
+export function usePangoLineageWithAlias(pangoLineage: string) {
+  const { data } = useQuery(fetchPangoLineageAliases, []);
+
+  if (data === undefined) {
+    return pangoLineage;
+  }
+
+  const alias: PangoLineageAlias | undefined = data
+    .filter(lineageAlias => pangoLineage.includes(lineageAlias.fullName + '.'))
+    .sort((a, b) => b.fullName.length - a.fullName.length)[0];
+  if (!alias) {
+    return pangoLineage;
+  }
+  return pangoLineage.replace(alias.fullName, alias.alias);
+}


### PR DESCRIPTION
Resolves #585

Further refactoring is possible for PangoLineageAliasResolverService but not attempted because it is nested into custom useQuery and thus too much work for now. Actually the PangoLineageAliasResolverService should be replaced by usePangoLineageFullName and usePangoLineageWithAlias.