### PR TITLE
ci: make sure that dependabot can push Docker images

### DIFF
--- a/.github/workflows/gisaid_docker.yml
+++ b/.github/workflows/gisaid_docker.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - name: Set environment variable "BRANCH"

--- a/.github/workflows/open_docker.yml
+++ b/.github/workflows/open_docker.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - name: Set environment variable "BRANCH"


### PR DESCRIPTION
When dependabot merges a PR, the push of the Docker image fails (see currently last develop build). This solution grants write permissions on packages to the Github token used in the job.