### PR TITLE
fix: chat history browsing with arrow up and down

### DIFF
--- a/src/components/chat/CustomMessageInput.tsx
+++ b/src/components/chat/CustomMessageInput.tsx
@@ -14,16 +14,18 @@ export type CustomMessageInputProps = {
 type MessageInputTriplet = {
   innerHtml: string;
   textContent: string;
-  innerText: string;
+  innerText: string | undefined;
+};
+
+const EMPTY_CHAT_INPUT = {
+  innerHtml: '<br>',
+  textContent: '<br>',
+  innerText: '',
 };
 
 export const CustomMessageInput = ({ disabled, maxLength, onMessageSend }: CustomMessageInputProps) => {
   const [messageInputRef, setMessageInputFocus] = useFocus();
-  const [contentInMessageInput, setContentInMessageInput] = useState<MessageInputTriplet>({
-    innerHtml: '',
-    textContent: '',
-    innerText: '',
-  });
+  const [contentInMessageInput, setContentInMessageInput] = useState<MessageInputTriplet>(EMPTY_CHAT_INPUT);
   const [history, setHistory] = useState<string[]>([]);
   const [historyPosition, setHistoryPosition] = useState<number | undefined>();
 
@@ -43,12 +45,19 @@ export const CustomMessageInput = ({ disabled, maxLength, onMessageSend }: Custo
   }
 
   useEffect(() => {
-    if (contentInMessageInput.textContent.length === 0) {
+    if (
+      typeof contentInMessageInput.innerText === 'string' &&
+      contentInMessageInput.innerText.trim().length === 0
+    ) {
       setHistoryPosition(history.length);
     }
-  }, [contentInMessageInput.textContent, history]);
+  }, [contentInMessageInput.innerText, history]);
 
-  const changeContentFromUserTyping = (innerHtml: string, textContent: string, innerText: string) => {
+  const changeContentFromUserTyping = (
+    innerHtml: string,
+    textContent: string,
+    innerText: string | undefined
+  ) => {
     if (textContent.length <= maxLength) {
       setContentInMessageInput({ innerHtml, textContent, innerText });
     }
@@ -63,19 +72,20 @@ export const CustomMessageInput = ({ disabled, maxLength, onMessageSend }: Custo
       if (newProposedPosition < 0 || newProposedPosition > history.length) {
         return;
       }
-      let content: string;
+      let content;
       if (newProposedPosition === history.length) {
-        content = '';
+        content = EMPTY_CHAT_INPUT;
       } else {
-        content = history[newProposedPosition];
+        const text = history[newProposedPosition];
+        content = { innerHtml: text, textContent: text, innerText: text };
       }
       setHistoryPosition(newProposedPosition);
-      setContentInMessageInput({ innerHtml: content, textContent: content, innerText: content });
+      setContentInMessageInput(content);
     }
   };
 
   const sendMessage = async (content: string, randomlyGenerated?: boolean) => {
-    setContentInMessageInput({ innerHtml: '', textContent: '', innerText: '' });
+    setContentInMessageInput(EMPTY_CHAT_INPUT);
     setHistory([...history, content]);
     onMessageSend(content, randomlyGenerated);
   };
@@ -132,7 +142,8 @@ export const CustomMessageInput = ({ disabled, maxLength, onMessageSend }: Custo
           style={{
             fontSize: '1.2em',
           }}
-          onClick={() => sendMessage(contentInMessageInput.innerText)}
+          placeholder={'Send'}
+          onClick={() => sendMessage(contentInMessageInput.textContent)}
         />
         <ProgressBar
           striped

--- a/src/components/chat/__tests__/CustomMessageInput.test.tsx
+++ b/src/components/chat/__tests__/CustomMessageInput.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react';
+import { CustomMessageInput } from '../CustomMessageInput';
+import userEvent from '@testing-library/user-event';
+
+const onMessageSendMock = jest.fn();
+
+describe('CustomMessageInput', () => {
+  const maxLength = 30;
+
+  function renderCustomerMessageInput(args: { disabled: boolean } = { disabled: false }) {
+    render(
+      <CustomMessageInput disabled={args.disabled} maxLength={maxLength} onMessageSend={onMessageSendMock} />
+    );
+  }
+
+  function getMessageInput() {
+    // eslint-disable-next-line testing-library/no-node-access -- Alternative suggestions are welcome, I didn't find a way to use testing library tools
+    return document.querySelector('div[contenteditable="true"],div[contenteditable="false"]')!;
+  }
+
+  async function typeMessage(message: string) {
+    await userEvent.click(getMessageInput());
+    await userEvent.type(getMessageInput(), message);
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should accept no input when disabled', async () => {
+    renderCustomerMessageInput({ disabled: true });
+
+    await typeMessage('my message');
+
+    expect(getMessageInput()).toHaveTextContent('');
+  });
+
+  test('should display the typed input', async () => {
+    renderCustomerMessageInput();
+
+    await typeMessage('my message');
+
+    expect(getMessageInput()).toHaveTextContent('my message');
+  });
+
+  test('should not allow more input than the max length permits', async () => {
+    renderCustomerMessageInput();
+
+    await typeMessage(`this is a very long message with more than ${maxLength} characters`);
+
+    expect(getMessageInput()).toHaveTextContent('this is a very long message wi');
+  });
+
+  test('should send message when hitting enter', async () => {
+    renderCustomerMessageInput();
+
+    await typeMessage('my message{enter}');
+
+    expect(getMessageInput()).toHaveTextContent('');
+    expect(onMessageSendMock).toHaveBeenCalledWith('my message', undefined);
+  });
+
+  test('should send message when pressing send button', async () => {
+    renderCustomerMessageInput();
+
+    await typeMessage('my message');
+    await userEvent.click(screen.getByPlaceholderText('Send'));
+
+    expect(getMessageInput()).toHaveTextContent('');
+    expect(onMessageSendMock).toHaveBeenCalledWith('my message', undefined);
+  });
+
+  async function sendMessages(firstMessage: string, secondMessage: string) {
+    await typeMessage(firstMessage);
+    await userEvent.click(screen.getByPlaceholderText('Send'));
+    expect(onMessageSendMock).toHaveBeenCalledWith(firstMessage, undefined);
+
+    await typeMessage(secondMessage);
+    await userEvent.click(screen.getByPlaceholderText('Send'));
+    expect(onMessageSendMock).toHaveBeenCalledWith(secondMessage, undefined);
+  }
+
+  test('should scroll through prompt history when pressing arrow up and down', async () => {
+    let firstMessage = 'first message';
+    let secondMessage = 'second message';
+
+    renderCustomerMessageInput();
+
+    await sendMessages(firstMessage, secondMessage);
+
+    await userEvent.click(getMessageInput());
+    expect(getMessageInput()).toHaveTextContent('');
+    expect(getMessageInput()).toHaveFocus();
+
+    await userEvent.keyboard('{arrowup}');
+    expect(getMessageInput()).toHaveTextContent(secondMessage);
+
+    await userEvent.keyboard('{arrowdown}');
+    expect(getMessageInput()).toHaveTextContent('');
+
+    await userEvent.keyboard('{arrowdown}');
+    expect(getMessageInput()).toHaveTextContent('');
+
+    await userEvent.keyboard('{arrowup}');
+    expect(getMessageInput()).toHaveTextContent(secondMessage);
+
+    await userEvent.keyboard('{arrowup}');
+    expect(getMessageInput()).toHaveTextContent(firstMessage);
+
+    await userEvent.keyboard('{arrowup}');
+    expect(getMessageInput()).toHaveTextContent(firstMessage);
+
+    await userEvent.keyboard('{arrowdown}');
+    expect(getMessageInput()).toHaveTextContent(secondMessage);
+  });
+
+  test('should stop scrolling through prompt history when editing a prompt after selecting it from the history', async () => {
+    let firstMessage = 'first message';
+    let secondMessage = 'second message';
+
+    renderCustomerMessageInput();
+
+    await sendMessages(firstMessage, secondMessage);
+    await userEvent.click(getMessageInput());
+
+    await userEvent.keyboard('{arrowup}');
+    expect(getMessageInput()).toHaveTextContent(secondMessage);
+
+    await userEvent.keyboard('{end} and more text');
+    let expectedTextAfterTyping = `${secondMessage} and more text`;
+    expect(getMessageInput()).toHaveTextContent(expectedTextAfterTyping);
+
+    await userEvent.keyboard('{arrowup}');
+    expect(getMessageInput()).toHaveTextContent(expectedTextAfterTyping);
+
+    await userEvent.keyboard('{arrowdown}');
+    expect(getMessageInput()).toHaveTextContent(expectedTextAfterTyping);
+  });
+});


### PR DESCRIPTION
resolves #777

Firefox behaves weirdly if the "empty" contenteditable div contains an empty string. Firefox by default puts at <br> there, even if the div is "empty".