### PR TITLE
Tooltips of wastewater plots are not completely visible

### DIFF
--- a/src/components/PackedGrid/PackedGrid.tsx
+++ b/src/components/PackedGrid/PackedGrid.tsx
@@ -72,7 +72,7 @@ export const PackedGrid = ({ children, maxColumns }: Props) => {
               key={child.key === null ? `child-${cell.index}` : `child-around-${child.key}`}
               node={portalNodes[cell.index]}
             >
-              <div style={{ width: cell.width, overflow: 'hidden' }}>{child.props.children}</div>
+              <div style={{ width: cell.width }}>{child.props.children}</div>
             </InPortal>
           );
         })

--- a/src/models/wasteWater/WasteWaterLocationTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterLocationTimeChart.tsx
@@ -3,10 +3,11 @@ import { WasteWaterTimeseriesSummaryDataset } from './types';
 import { UnifiedDay } from '../../helpers/date-cache';
 import { getTicks } from '../../helpers/ticks';
 import { TitleWrapper, Wrapper } from '../../widgets/common';
-import { ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Line, LineChart, ResponsiveContainer, Tooltip, TooltipProps, XAxis, YAxis } from 'recharts';
 import { formatDate } from './WasteWaterTimeChart';
 import { wastewaterVariantColors } from './constants';
 import { Utils } from '../../services/Utils';
+import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
 
 interface Props {
   variants: {
@@ -16,11 +17,11 @@ interface Props {
 }
 
 interface VariantMap {
-  [key: string]: number;
+  [variantName: string]: number;
 }
 
 interface CIMap {
-  [key: string]: [number, number];
+  [variantName: string]: [number, number];
 }
 
 /**
@@ -37,21 +38,77 @@ function deEscapeValueName(escapedName: string): string {
 
 const CHART_MARGIN_RIGHT = 15;
 
+function formatProportion(value: number): string {
+  return (Number(value) * 100).toFixed(2);
+}
+
+function formatPercent(value: number): string {
+  return formatProportion(value) + '%';
+}
+
+function formatCiPercent(ci: [number, number]): string {
+  return `[${formatProportion(ci[0])} - ${formatPercent(ci[1])}]`;
+}
+
+const TooltipRow = ({
+  name,
+  proportion,
+  proportionCI,
+  color,
+}: {
+  name: string;
+  proportion: number;
+  proportionCI: [number, number];
+  color: string;
+}) => {
+  function format(name: string, value: number, ci: [number, number]): string {
+    return `${deEscapeValueName(name)}: ${formatPercent(value)} ${formatCiPercent(ci)}`;
+  }
+
+  return <p style={{ color: color }}>{format(name, proportion, proportionCI)}</p>;
+};
+
+const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
+  if (active && payload && payload.length > 0) {
+    return (
+      <div className='custom-tooltip'>
+        <div>Date: {formatDate(payload[0].payload.date)}</div>
+        <div>
+          {payload.map((p: any) => {
+            const name = p.name.replace('proportions.', '');
+            return (
+              <TooltipRow
+                key={`tooltipRow${name}`}
+                name={name}
+                proportion={p.payload.proportions[name]}
+                proportionCI={p.payload.proportionCIs[name]}
+                color={p.color}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+
 export const WasteWaterLocationTimeChart = React.memo(({ variants }: Props): JSX.Element => {
-  const variantNames = variants.map(d => escapeValueName(d.name));
-  const dateMap: Map<UnifiedDay, { date: number; values: VariantMap; cis: CIMap }> = new Map();
+  const escapedVariantNames = variants.map(variant => escapeValueName(variant.name));
+  const dateMap: Map<UnifiedDay, { date: number; proportions: VariantMap; proportionCIs: CIMap }> = new Map();
 
   for (let { name, data } of variants) {
     for (let { date, proportion, proportionCI } of data) {
       if (!dateMap.has(date)) {
         dateMap.set(date, {
           date: date.dayjs.valueOf(),
-          values: {},
-          cis: {},
+          proportions: {},
+          proportionCIs: {},
         });
       }
-      dateMap.get(date)!.values[escapeValueName(name)] = Math.max(proportion, 0);
-      dateMap.get(date)!.cis[escapeValueName(name)] = proportionCI;
+      dateMap.get(date)!.proportions[escapeValueName(name)] = Math.max(proportion, 0);
+      dateMap.get(date)!.proportionCIs[escapeValueName(name)] = proportionCI;
     }
   }
 
@@ -64,7 +121,11 @@ export const WasteWaterLocationTimeChart = React.memo(({ variants }: Props): JSX
     <Wrapper>
       <TitleWrapper>Estimated prevalence in wastewater samples</TitleWrapper>
       <ResponsiveContainer>
-        <ComposedChart data={plotData} margin={{ top: 6, right: CHART_MARGIN_RIGHT, left: 0, bottom: 0 }}>
+        <LineChart
+          data={plotData}
+          margin={{ top: 6, right: CHART_MARGIN_RIGHT, left: 0, bottom: 0 }}
+          data-testid='ComposedChart-chart'
+        >
           <XAxis
             dataKey='date'
             scale='time'
@@ -75,35 +136,28 @@ export const WasteWaterLocationTimeChart = React.memo(({ variants }: Props): JSX
           />
           <YAxis domain={['dataMin', 'auto']} />
           <Tooltip
-            formatter={(value: string, name: string, props: any) => {
-              const escapedName = name.replace('values.', '');
-              const [ciLower, ciUpper] = props.payload.cis[escapedName];
-              return [
-                (Number(value) * 100).toFixed(2) +
-                  '% [' +
-                  (ciLower * 100).toFixed(2) +
-                  '-' +
-                  (ciUpper * 100).toFixed(2) +
-                  '%]',
-                deEscapeValueName(escapedName),
-              ];
+            content={<CustomTooltip />}
+            wrapperStyle={{
+              backgroundColor: 'white',
+              border: '2px solid #ccc',
+              borderRadius: '5px',
             }}
-            labelFormatter={label => {
-              return 'Date: ' + formatDate(label);
-            }}
+            position={{ y: -80 }}
           />
-          {variantNames.map(variant => (
+          {escapedVariantNames.map(escapedVariant => (
             <Line
               type='monotone'
-              dataKey={'values.' + variant}
+              dataKey={'proportions.' + escapedVariant}
               strokeWidth={3}
-              stroke={wastewaterVariantColors[deEscapeValueName(variant)] ?? Utils.getRandomColorCode()}
+              stroke={
+                wastewaterVariantColors[deEscapeValueName(escapedVariant)] ?? Utils.getRandomColorCode()
+              }
               dot={false}
               isAnimationActive={false}
-              key={variant}
+              key={escapedVariant}
             />
           ))}
-        </ComposedChart>
+        </LineChart>
       </ResponsiveContainer>
     </Wrapper>
   );

--- a/src/models/wasteWater/WasteWaterLocationTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterLocationTimeChart.tsx
@@ -141,8 +141,8 @@ export const WasteWaterLocationTimeChart = React.memo(({ variants }: Props): JSX
               backgroundColor: 'white',
               border: '2px solid #ccc',
               borderRadius: '5px',
+              zIndex: 1000,
             }}
-            position={{ y: -80 }}
           />
           {escapedVariantNames.map(escapedVariant => (
             <Line

--- a/src/models/wasteWater/story/WasteWaterStoryPage.tsx
+++ b/src/models/wasteWater/story/WasteWaterStoryPage.tsx
@@ -40,7 +40,10 @@ export const WasteWaterStoryPage = () => {
             variants={variantsTimeseriesSummaries}
             height={300}
             toolbarChildren={[
-              <ShowMoreButton to={'/story/wastewater-in-switzerland/location/' + location} />,
+              <ShowMoreButton
+                to={'/story/wastewater-in-switzerland/location/' + location}
+                key={`showmore${location}`}
+              />,
             ]}
           />
         ),


### PR DESCRIPTION
Resolves #788

This is a first draft of the fix. Currently the position of the tooltip is raised by 80. This works on my screen, and also with smaller window sizes. It works also on the mobile emulator, but there is not the problem, that all is shown, but that too much is shown. An increase of the zindex did not fix the issue. There might be more to it, but I could not find it, why this does not work.

If we get more variants, I think we can go the route to reduce the spacing between the lines, or to migrate to a two column view.

Sadly, I could not write a tests, since I was unable to get the tooltip to show. I could not find an element, to hover over, which worked.

So, feedback welcome :)