### PR TITLE
updated variants colors

### DIFF
--- a/src/models/wasteWater/constants.ts
+++ b/src/models/wasteWater/constants.ts
@@ -12,6 +12,8 @@ export const wastewaterVariantColors: {
   'BA.5': '#595EF6',
   'BA.2.75': '#DE9ADB',
   'BQ.1.1': '#8fe000', // improv, not in sync with covariants.org
-  'XBB': '#dd6bff',
+  'XBB.1.9': '#dd6bff', // improv, not in sync with covariants.org
+  'XBB.1.5': '#ff5656',
+  'XBB.1.16': '#e99b30',
   'undetermined': '#999696',
 };


### PR DESCRIPTION
After including XBB.1.5, XBB.1.16 and XBB.1.9 as well as excluding the general XBB*, I updated the colors for the curves according to the colors suggested by covariants