### PR TITLE
fix(#842): pass LapisDataVersion as prop into footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,7 @@ import { WasteWaterLocationPage } from './models/wasteWater/story/WasteWaterLoca
 import StoriesOverview from './stories/StoriesOverview';
 import StoryRouter from './stories/StoryRouter';
 import { useExploreUrl } from './helpers/explore-url';
-import dayjs from 'dayjs';
-import { fetchNextcladeDatasetInfo, getCurrentLapisDataVersionDate } from './data/api-lapis';
+import { fetchNextcladeDatasetInfo, fetchLapisDataVersion } from './data/api-lapis';
 import { sequenceDataSource } from './helpers/sequence-data-source';
 import { ExternalLink } from './components/ExternalLink';
 import styled from 'styled-components';
@@ -59,6 +58,7 @@ export const App = () => {
   const isSmallScreen = width !== undefined && width < 768;
 
   const { data: nextcladeDatasetInfo } = useQuery(() => fetchNextcladeDatasetInfo(), []);
+  const { data: lapisDataVersion } = useQuery(() => fetchLapisDataVersion(), []);
 
   const isChatPage = useLocation().pathname === '/chat';
   const showFooter = !hideHeaderAndFooter && !isChatPage;
@@ -73,7 +73,9 @@ export const App = () => {
           setHideHeaderAndFooter={setHideHeaderAndFooter}
         />
       </div>
-      {showFooter && <Footer nextcladeDatasetInfo={nextcladeDatasetInfo} />}
+      {showFooter && (
+        <Footer nextcladeDatasetInfo={nextcladeDatasetInfo} lapisDataVersion={lapisDataVersion} />
+      )}
       {!isSmallScreen && !isChatPage && <FixedChatButton />}
     </div>
   );
@@ -246,12 +248,16 @@ function CovSpectrumRoutes({
   );
 }
 
-function Footer({ nextcladeDatasetInfo }: { nextcladeDatasetInfo?: NextcladeDatasetInfo }) {
+function Footer({
+  nextcladeDatasetInfo,
+  lapisDataVersion,
+}: {
+  nextcladeDatasetInfo?: NextcladeDatasetInfo;
+  lapisDataVersion?: string;
+}) {
   return (
     <FooterStyle className='text-center'>
-      <div>
-        The sequence data was updated: {dayjs(getCurrentLapisDataVersionDate()).locale('en').calendar()}
-      </div>
+      {lapisDataVersion && <div>The sequence data was updated: {lapisDataVersion}</div>}
       {nextcladeDatasetInfo?.tag && <div>Nextclade dataset version: {nextcladeDatasetInfo.tag}</div>}
       {sequenceDataSource === 'gisaid' && (
         <div>

--- a/src/baseLocation.ts
+++ b/src/baseLocation.ts
@@ -1,8 +1,0 @@
-import { fetchLapisDataVersionDate } from './data/api-lapis';
-
-(async () => {
-  try {
-    // Fetch current data version of LAPIS
-    await fetchLapisDataVersionDate();
-  } catch (_) {}
-})();

--- a/src/data/__mocks__/api-lapis.ts
+++ b/src/data/__mocks__/api-lapis.ts
@@ -4,8 +4,8 @@ export async function fetchAllHosts(): Promise<string[]> {
   return Promise.resolve(['mockHost']);
 }
 
-export function getCurrentLapisDataVersionDate(): Date | undefined {
-  return undefined;
+export async function fetchLapisDataVersion(): Promise<string> {
+  return 'mockVersion';
 }
 
 export async function fetchNextcladeDatasetInfo(): Promise<NextcladeDatasetInfo> {

--- a/src/data/api-lapis.ts
+++ b/src/data/api-lapis.ts
@@ -50,7 +50,7 @@ export const get = async (endpoint: string, signal?: AbortSignal, omitDataVersio
   return res;
 };
 
-export async function fetchLapisDataVersionDate(signal?: AbortSignal) {
+export async function fetchLapisDataVersion(signal?: AbortSignal): Promise<string> {
   let url = '/sample/info';
   if (ACCESS_KEY) {
     url += '?accessKey=' + ACCESS_KEY;
@@ -61,6 +61,7 @@ export async function fetchLapisDataVersionDate(signal?: AbortSignal) {
   }
   const info = (await res.json()) as LapisInformation;
   currentLapisDataVersion = info.dataVersion;
+  return dayjs.unix(currentLapisDataVersion).locale('en').calendar();
 }
 
 export function getCurrentLapisDataVersionDate(): Date | undefined {


### PR DESCRIPTION
resolves #842

Make sure that the lapisDataVersion is passed as a prop, rather than relying on a global variable

Mirror fetchNextcladeDatasetInfo pattern for implementation

Get rid of strange code remnant baseLocation.ts that seemd to have nothing to do with the baseLocation
