### PR TITLE
BA.2.86 colour in constants.ts

### DIFF
--- a/src/models/wasteWater/constants.ts
+++ b/src/models/wasteWater/constants.ts
@@ -17,5 +17,6 @@ export const wastewaterVariantColors: {
   'XBB.1.16': '#e99b30',
   'XBB.2.3': '#b4b82a', // improv, not in sync with covariants.org
   'EG.5': '#359f99', // improv, not in sync with covariants.org
+  'BA.2.86': '#FF20E0', // improv, not in sync with covariants.org
   'undetermined': '#999696',
 };


### PR DESCRIPTION
- No official colour in covariants.org
- BA.2.86 deconvolution is active for Wastewater (though curves close to 0 for now).