### PR TITLE
Use locale for time conversion for wastewater, not iso time string

### DIFF
--- a/src/models/wasteWater/WasteWaterLocationTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterLocationTimeChart.tsx
@@ -4,13 +4,13 @@ import { UnifiedDay } from '../../helpers/date-cache';
 import { getTicks } from '../../helpers/ticks';
 import { TitleWrapper, Wrapper } from '../../widgets/common';
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import { formatDate } from './WasteWaterTimeChart';
 import { wastewaterVariantColors } from './constants';
 import { Utils } from '../../services/Utils';
 import { DateRange } from '../../data/DateRange';
 import { WasteWaterTooltip } from './WasteWaterLocationTimeChartTooltip';
 import { formatPercent } from '../../helpers/format-data';
 import { deEscapeValueName, escapeValueName } from './RechartsKeyConversion';
+import { formatDate } from '../../widgets/VariantTimeDistributionLineChartInner';
 
 interface Props {
   variants: {

--- a/src/models/wasteWater/WasteWaterLocationTimeChartTooltip.tsx
+++ b/src/models/wasteWater/WasteWaterLocationTimeChartTooltip.tsx
@@ -1,9 +1,9 @@
 import { TooltipProps } from 'recharts';
 import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
-import { formatDate } from './WasteWaterTimeChart';
 import React from 'react';
 import { formatCiPercent, formatPercent } from '../../helpers/format-data';
 import { deEscapeValueName } from './RechartsKeyConversion';
+import { formatDate } from '../../widgets/VariantTimeDistributionLineChartInner';
 
 export const WasteWaterTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
   if (!(active && payload && payload.length > 0)) {

--- a/src/models/wasteWater/WasteWaterSummaryTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterSummaryTimeChart.tsx
@@ -4,11 +4,11 @@ import { schemeCategory10 } from 'd3-scale-chromatic';
 import { ChartAndMetricsWrapper, ChartWrapper, TitleWrapper, Wrapper } from '../../widgets/common';
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { WasteWaterTimeseriesSummaryDataset } from './types';
-import { formatDate } from './WasteWaterTimeChart';
 import { getTicks } from '../../helpers/ticks';
 import { UnifiedDay } from '../../helpers/date-cache';
 import { escapeValueName } from './RechartsKeyConversion';
 import { WasteWaterTooltip } from './WasteWaterLocationTimeChartTooltip';
+import { formatDate } from '../../widgets/VariantTimeDistributionLineChartInner';
 
 interface Props {
   wasteWaterPlants: {

--- a/src/models/wasteWater/WasteWaterTimeChart.tsx
+++ b/src/models/wasteWater/WasteWaterTimeChart.tsx
@@ -5,10 +5,7 @@ import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis }
 import { WasteWaterTimeEntry, WasteWaterTimeseriesSummaryDataset } from './types';
 import { getTicks } from '../../helpers/ticks';
 import { TooltipSideEffect } from '../../components/RechartsTooltip';
-
-export function formatDate(date: number) {
-  return new Date(date).toISOString().split('T')[0];
-}
+import { formatDate } from '../../widgets/VariantTimeDistributionLineChartInner';
 
 interface Props {
   data: WasteWaterTimeseriesSummaryDataset;

--- a/src/models/wasteWater/__tests__/WasteWaterLocationTimeChart.test.tsx
+++ b/src/models/wasteWater/__tests__/WasteWaterLocationTimeChart.test.tsx
@@ -4,7 +4,7 @@ import { WasteWaterLocationTimeChart } from '../WasteWaterLocationTimeChart';
 import { globalDateCache } from '../../../helpers/date-cache';
 import { WasteWaterTimeseriesSummaryDataset } from '../types';
 import { getTicks } from '../../../helpers/ticks';
-import { formatDate } from '../WasteWaterTimeChart';
+import { formatDate } from '../../../widgets/VariantTimeDistributionLineChartInner';
 
 jest.mock('recharts', () => {
   const OriginalModule = jest.requireActual('recharts');

--- a/src/models/wasteWater/loading.ts
+++ b/src/models/wasteWater/loading.ts
@@ -2,7 +2,6 @@ import {
   WasteWaterDataset,
   WasteWaterDatasetEntry,
   WasteWaterRequest,
-  WasteWaterResponse,
   WasteWaterResponseSchema,
 } from './types';
 import { get } from '../../data/api';
@@ -22,7 +21,7 @@ export async function getData(
     return undefined;
   }
 
-  const responseData: WasteWaterResponse = WasteWaterResponseSchema.parse(json);
+  const responseData = WasteWaterResponseSchema.parse(json);
 
   // fall back json parsing in case zod is slow
   //const responseData = json as WasteWaterResponse;
@@ -50,10 +49,7 @@ export function filter(data: WasteWaterDataset, variantName?: string, location?:
     if (variantName && d.variantName !== variantName) {
       return false;
     }
-    if (location && d.location !== location) {
-      return false;
-    }
-    return true;
+    return !(location && d.location !== location);
   });
 }
 

--- a/src/models/wasteWater/types.ts
+++ b/src/models/wasteWater/types.ts
@@ -7,8 +7,6 @@ export const WasteWaterSelectorSchema = zod.object({
   location: zod.string().optional(),
 });
 
-export type WasteWaterSelector = zod.infer<typeof WasteWaterSelectorSchema>;
-
 export type WasteWaterRequest = {
   country: string;
 };
@@ -40,8 +38,6 @@ export const WasteWaterResponseSchema = zod.object({
     })
   ),
 });
-
-export type WasteWaterResponse = zod.infer<typeof WasteWaterResponseSchema>;
 
 export type WasteWaterTimeEntry = {
   date: UnifiedDay;


### PR DESCRIPTION
Resolves #896 

Now the time string is no longer converted from the ISO time, but the locale, where the user looks at the data. This is now the same way as all the others plots on cov-spectrum.