### PR TITLE
feat: queue LAPIS calls on collection pages

### DIFF
--- a/src/helpers/PromiseQueue.ts
+++ b/src/helpers/PromiseQueue.ts
@@ -30,3 +30,10 @@ export class PromiseQueue {
     }
   }
 }
+
+export function promiseAllSettledQueued<T>(promiseSuppliers: (() => Promise<T>)[], batchSize: number) {
+  const promiseQueue = new PromiseQueue(batchSize);
+  return Promise.allSettled(
+    promiseSuppliers.map(promiseSupplier => promiseQueue.addTask(() => promiseSupplier()))
+  );
+}


### PR DESCRIPTION
resolves #980 

The very large collection 24 (~1000 variants) will otherwise fail to load in Chrome with "net::ERR_INSUFFICIENT_RESOURCES"

With this fix, both collections successfully load in Chrome:
https://cov-spectrum-develop-git-980-improve-collec-dc213c-cov-spectrum.vercel.app/collections/127
https://cov-spectrum-develop-git-980-improve-collec-dc213c-cov-spectrum.vercel.app/collections/24