### PR TITLE
add XEC and update KP.3 in constants.ts

### DIFF
--- a/src/models/wasteWater/constants.ts
+++ b/src/models/wasteWater/constants.ts
@@ -23,7 +23,8 @@ export const wastewaterVariantColors: {
   'JN.1': '#00E9FF', // improv, not in sync with covariants.org
   'BA.2.87.1': '#56ACBC', //improv, not in sync with covariants.org
   'KP.2': '#876566', //improv not in sync with covariants.org
-  'KP.3': '#eebebf', //improv not in sync with covariants.org
+  'KP.3': '#331eee',
+  "XEC": "#a2a626", //improv not in sync with covariants.org
   'undetermined': '#969696',
 };
 


### PR DESCRIPTION
Added the color constant for variant XEC (improvised and currently not present at covariants.org). Updated the color constant for variant KP.3 to match covariants.org