### PR TITLE
fix: use new Usher URL

### DIFF
--- a/src/models/wasteWater/constants.ts
+++ b/src/models/wasteWater/constants.ts
@@ -24,7 +24,7 @@ export const wastewaterVariantColors: {
   'BA.2.87.1': '#56ACBC', //improv, not in sync with covariants.org
   'KP.2': '#876566', //improv not in sync with covariants.org
   'KP.3': '#331eee',
-  "XEC": "#a2a626", //improv not in sync with covariants.org
+  'XEC': '#a2a626', //improv not in sync with covariants.org
   'undetermined': '#969696',
 };
 

--- a/src/services/external-integrations/UsherIntegration.ts
+++ b/src/services/external-integrations/UsherIntegration.ts
@@ -5,8 +5,8 @@ import { OrderAndLimitConfig } from '../../data/OrderAndLimitConfig';
 import { LapisSelector } from '../../data/LapisSelector';
 
 const usherUrl =
-  'https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&phyloPlaceTree=hgPhyloPlaceData/wuhCor1' +
-  '/public.plusGisaid.latest.masked.pb&subtreeSize=5000&remoteFile=';
+  'https://genome.ucsc.edu/cgi-bin/hgPhyloPlace?db=wuhCor1&hgpp_org=wuhCor1&phyloPlaceTree=/gbdb/wuhCor1' +
+  '/hgPhyloPlaceData/public.plusGisaid.latest.masked.pb&subtreeSize=5000&remoteFile=';
 const defaultOrderAndLimit: OrderAndLimitConfig = { orderBy: 'random', limit: 400 };
 
 export class UsherIntegration implements Integration {


### PR DESCRIPTION
I figured out the new parameters by looking at what the Usher website itself POSTs:

```
hgsid: 423269897_2Rzs1ZBNI21IDAqmdC0WA8nw67gc
hgpp_org: wuhCor1
sarsCoV2File: (binary)
namesOrIds: S:K478T, India
phyloPlaceTree: /gbdb/wuhCor1/hgPhyloPlaceData/public.plusGisaid.latest.masked.pb
subtreeSize: 5000
submit: Upload
```

Resolves #1035
