### PR TITLE
fix: make the normal (non-advanced) lineage search case-insensitive

### DIFF
--- a/src/components/VariantSearchField.tsx
+++ b/src/components/VariantSearchField.tsx
@@ -122,9 +122,9 @@ function optionsToVariantSelector(options: SearchOption[]): VariantSelector {
     } else if (type === 'nuc-insertion') {
       selector.nucInsertions!.push(value);
     } else if (type === 'pango-lineage') {
-      selector.pangoLineage = value;
+      selector.pangoLineage = value.toUpperCase();
     } else if (type === 'nextclade-pango-lineage') {
-      selector.nextcladePangoLineage = value;
+      selector.nextcladePangoLineage = value.toUpperCase();
     } else if (type === 'nextstrain-clade') {
       selector.nextstrainClade = value;
     }

--- a/src/data/VariantSelector.ts
+++ b/src/data/VariantSelector.ts
@@ -121,8 +121,8 @@ export function readVariantListFromUrlSearchParams(params: URLSearchParams): Var
   // Create the variant selectors.
   const variants: VariantSelector[] = [
     {
-      pangoLineage: params.get('pangoLineage') ?? undefined,
-      nextcladePangoLineage: params.get('nextcladePangoLineage') ?? undefined,
+      pangoLineage: params.get('pangoLineage')?.toUpperCase() ?? undefined,
+      nextcladePangoLineage: params.get('nextcladePangoLineage')?.toUpperCase() ?? undefined,
       gisaidClade: params.get('gisaidClade') ?? undefined,
       nextstrainClade: params.get('nextstrainClade') ?? undefined,
       aaMutations: params.get('aaMutations')?.split(','),
@@ -134,8 +134,8 @@ export function readVariantListFromUrlSearchParams(params: URLSearchParams): Var
   ];
   for (let id of variantIds) {
     variants.push({
-      pangoLineage: params.get('pangoLineage' + id) ?? undefined,
-      nextcladePangoLineage: params.get('nextcladePangoLineage' + id) ?? undefined,
+      pangoLineage: params.get('pangoLineage' + id)?.toUpperCase() ?? undefined,
+      nextcladePangoLineage: params.get('nextcladePangoLineage' + id)?.toUpperCase() ?? undefined,
       gisaidClade: params.get('gisaidClade' + id) ?? undefined,
       nextstrainClade: params.get('nextstrainClade' + id) ?? undefined,
       aaMutations: params.get('aaMutations' + id)?.split(','),


### PR DESCRIPTION
Previously, searching for a lineage using lower case (e.g., `xbb.1`) didn't work. This fix it for the normal (non-advanced) search. In advanced search, lower case still cause an error / non-responsiveness.

Example: https://cov-spectrum.org/explore/Switzerland/AllSamples/Past6M/variants?nextcladePangoLineage=xbb.1*& didn't work before, after this, it should work. https://cov-spectrum.org/explore/Switzerland/AllSamples/Past6M/variants?variantQuery=nextcladePangoLineage%3Axbb.1*& still doesn't work.