### PR TITLE
Wastewater Stories: add confidence interval footnote

### DIFF
--- a/src/models/wasteWater/WasteWaterLocationTimeChartTooltip.tsx
+++ b/src/models/wasteWater/WasteWaterLocationTimeChartTooltip.tsx
@@ -24,8 +24,12 @@ export const WasteWaterTooltip = ({ active, payload }: TooltipProps<ValueType, N
               proportionCI={p.payload.proportionCIs[name]}
               color={p.color}
             />
+            
           );
         })}
+      </div>
+      <div style={{ fontSize: '0.85em', color: '#666', marginTop: '4px' }}>
+        mean [95% confidence interval]
       </div>
     </div>
   );

--- a/src/models/wasteWater/WasteWaterLocationTimeChartTooltip.tsx
+++ b/src/models/wasteWater/WasteWaterLocationTimeChartTooltip.tsx
@@ -24,7 +24,6 @@ export const WasteWaterTooltip = ({ active, payload }: TooltipProps<ValueType, N
               proportionCI={p.payload.proportionCIs[name]}
               color={p.color}
             />
-            
           );
         })}
       </div>


### PR DESCRIPTION
We realised that the page was not showing what the intervals we show are. 1 stdev, 2 stdev? 

Hence, I proposed we add a footnote to the confidence intervals shown on hover. We discussed this internally already. 