### PR TITLE
fix: replace react-boostrap collapse with tailwind collapse

### DIFF
--- a/src/models/wasteWater/story/WasteWaterStoryPage.tsx
+++ b/src/models/wasteWater/story/WasteWaterStoryPage.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Collapse } from 'react-bootstrap';
 import { ExternalLink } from '../../../components/ExternalLink';
 import { isDiscontinuedSite, WasteWaterSamplingSites } from './WasteWaterSamplingSites';
 import { discontinuedSites } from '../constants';
@@ -83,14 +82,12 @@ const DiscontinuedSiteSection = ({ site }: { site: (typeof discontinuedSites)[0]
         <span className='me-2'>{isOpen ? '▼' : '▶'}</span>
         Locations discontinued since{site.discontinuedDate}
       </h2>
-      <Collapse in={isOpen}>
-        <div>
-          <WasteWaterSamplingSites
-            locationFilter={location => site.discontinuedLocations.has(location)}
-            defaultDateRangeSelector={dateRangeSelector}
-          />
-        </div>
-      </Collapse>
+      <div className={isOpen ? 'visible' : 'collapse'}>
+        <WasteWaterSamplingSites
+          locationFilter={location => site.discontinuedLocations.has(location)}
+          defaultDateRangeSelector={dateRangeSelector}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
resolves #1142 

I'm not entirely sure what the issue was before with the `react-boostrap` component. I actually suspect that maybe its CSS classes were interfering with the tailwind classes?

Tailwind can also do collapsing, so I got rid of the `Collapse` component and used simple CSS classes instead.


https://github.com/user-attachments/assets/f5cf262a-8744-4cfd-ac46-461add7225c9

