### PR TITLE
fix: don't query server if mutation list is empty

### DIFF
--- a/src/components/VariantMutationsTimelines.tsx
+++ b/src/components/VariantMutationsTimelines.tsx
@@ -187,6 +187,9 @@ const useData = (
       if (filteredMutations.length > 70) {
         return 'too-big';
       }
+      if (filteredMutations.length === 0) {
+        return 'empty';
+      }
 
       const dayRange = globalDateCache.rangeFromDays(
         variantDateCounts.payload.filter(v => v.date).map(v => v.date!)


### PR DESCRIPTION
resolves #1163 

What happened? The issue was that a request was made to lapis with `includeMutations: []`. Then, LAPIS returned a response with `dataVersion: null`. And that caused an infinite reload because of this function:

```typescript
function _extractLapisData<T>(response: LapisResponse<T>): T {
  if (currentLapisDataVersion === undefined) {
    currentLapisDataVersion = Number(response.info.dataVersion);
  } else if (currentLapisDataVersion !== Number(response.info.dataVersion)) {
    console.log(
      `LAPIS has new data. Old version: ${currentLapisDataVersion}, new version: ${response.info.dataVersion}. ` +
        `The website will be reloaded.`
    );

    window.location.reload();
    throw new Error(
      `LAPIS has new data. Old version: ${currentLapisDataVersion}, new version: ${response.info.dataVersion}. ` +
        `The website will be reloaded.`
    );
  }
  return response.data;
}
```

@chaoran-chen already suggested that we should still return a non-null `dataVersion` in LAPIS even if the result is empty. I think that makes sense, I've created an issue for it here: https://github.com/GenSpectrum/LAPIS/issues/1440

The fix we're implementing now is to just check if the list of mutations is empty, and if so, don't make the request.