### PR TITLE
fix: styling of linkout buttons - add back the shadow to the menus

### DIFF
--- a/src/components/FocusVariantHeaderControls.tsx
+++ b/src/components/FocusVariantHeaderControls.tsx
@@ -15,7 +15,6 @@ import { LapisSelector } from '../data/LapisSelector';
 import { ExternalLink, ExternalLinkAsync } from './ExternalLink';
 
 // mui stuff
-import Button1 from '@mui/material/Button';
 import Button from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
 import { alpha, styled } from '@mui/material/styles';
@@ -26,7 +25,6 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 
 const StyledMenu = styled((props: MenuProps) => (
   <Menu
-    elevation={0}
     anchorOrigin={{
       vertical: 'bottom',
       horizontal: 'right',
@@ -38,13 +36,13 @@ const StyledMenu = styled((props: MenuProps) => (
     {...props}
   />
 ))(({ theme }) => ({
-  '& .MuiPaper-root': {
+  '& .MuiPaper-root.MuiPaper-root': {
     'borderRadius': 6,
     'marginTop': theme.spacing(1),
     'minWidth': 180,
     'color': theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
     'boxShadow':
-      'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
+      'rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px !important',
     '& .MuiMenu-list': {
       padding: '4px 0',
     },
@@ -151,7 +149,7 @@ export const FocusVariantHeaderControls = React.memo(({ selector }: Props): JSX.
           </MenuItem>
         </StyledMenu>
 
-        <Button1
+        <Button
           id='basic-button'
           aria-controls={open ? 'basic-menu' : undefined}
           aria-haspopup='true'
@@ -159,8 +157,8 @@ export const FocusVariantHeaderControls = React.memo(({ selector }: Props): JSX.
           onClick={handleClick}
         >
           Other websites
-        </Button1>
-        <Menu
+        </Button>
+        <StyledMenu
           disableScrollLock={true}
           id='basic-menu'
           anchorEl={anchorEl}
@@ -178,7 +176,7 @@ export const FocusVariantHeaderControls = React.memo(({ selector }: Props): JSX.
                 </MenuItem>
               )
           )}
-        </Menu>
+        </StyledMenu>
       </div>
     </>
   );

--- a/src/components/FocusVariantHeaderControls.tsx
+++ b/src/components/FocusVariantHeaderControls.tsx
@@ -36,6 +36,8 @@ const StyledMenu = styled((props: MenuProps) => (
     {...props}
   />
 ))(({ theme }) => ({
+  // The doubled selector and !important are needed to override a global
+  // `box-shadow: none !important` rule on .MuiPaper-root.MuiPaper-rounded.MuiPaper-elevation
   '& .MuiPaper-root.MuiPaper-root': {
     'borderRadius': 6,
     'marginTop': theme.spacing(1),

--- a/src/models/wasteWater/constants.ts
+++ b/src/models/wasteWater/constants.ts
@@ -28,7 +28,7 @@ export const wastewaterVariantColors: {
   'LP.8': '#11a90b',
   'NB.1.8.1': '#b3cb23',
   'XFG': '#bd8e23',
-  'BA.3.2': "#2EE6D6", //improv not in sync with covariants.org
+  'BA.3.2': '#2EE6D6', //improv not in sync with covariants.org
   'undetermined': '#969696',
 };
 


### PR DESCRIPTION
resolves #1138

The shadow on the menu is back:
<img width="317" height="175" alt="grafik" src="https://github.com/user-attachments/assets/1d30c30b-7234-407a-bdc1-26d3239386e2" />

<img width="355" height="193" alt="grafik" src="https://github.com/user-attachments/assets/c8695482-a017-4f9d-bb72-9105cb0a55f1" />
