### PR TITLE
fix: update stale gisaid_docker.yml reference in building docs

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -26,4 +26,4 @@ Many new features and the majority of the open issues can be implemented by only
 
 ## For production
 
-Production builds are done automatically in CI (see [.github/workflows/gisaid_docker.yml](/.github/workflows/gisaid_docker.yml)).
+Production builds are done automatically in CI (see [.github/workflows/open_docker.yml](/.github/workflows/open_docker.yml)).


### PR DESCRIPTION
Found by Claude while reviewing #1196 